### PR TITLE
Added full error to exception

### DIFF
--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -36,7 +36,7 @@ namespace DotNetOutdated.Core.Services
             }
 
             throw new CommandValidationException($"Unable to process the project `{projectPath}. Are you sure this is a valid .NET Core or .NET Standard project type?" +
-                                                 $"{Environment.NewLine}{Environment.NewLine}Here is the full error message returned from the Microsoft Build Engine:{Environment.NewLine}{Environment.NewLine}{runStatus.Output}");
+                                                 $"{Environment.NewLine}{Environment.NewLine}Here is the full error message returned from the Microsoft Build Engine:{Environment.NewLine}{Environment.NewLine}{runStatus.Output} - {runStatus.Errors} - exit code: {runStatus.ExitCode}");
         }
     }
 }


### PR DESCRIPTION
For debugging purposes, I added the full error message. In some cases only info about msbuild version like:
```
Microsoft (R) Build Engine version 16.6.0+5ff7b0c9e for .NET Core

Copyright (C) Microsoft Corporation. All rights reserved.
```

This means that the actual error log seem to be hidden and thus making debugging somewhat more difficult.