### PR TITLE
Replace deprecated call to DependencyGraphSpec(JObject)

### DIFF
--- a/src/DotNetOutdated.Core/DotNetOutdated.Core.csproj
+++ b/src/DotNetOutdated.Core/DotNetOutdated.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="NuGet.Configuration" Version="6.0.0" />
     <PackageReference Include="NuGet.Credentials" Version="6.0.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.11.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
     <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.47" />

--- a/src/DotNetOutdated.Core/TempDirectory.cs
+++ b/src/DotNetOutdated.Core/TempDirectory.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+
+namespace DotNetOutdated
+{
+    class TempDirectory : IDisposable
+    {
+        private string tempPath;
+        private string tempDirName;
+
+        public TempDirectory()
+        {
+            tempPath = Path.GetTempPath();
+            tempDirName = Path.GetRandomFileName();
+            Directory.CreateDirectory(DirectoryPath);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(DirectoryPath, true);
+        }
+
+        public string DirectoryPath
+        {
+            get => Path.Combine(tempPath, tempDirName);
+        }
+    }
+}


### PR DESCRIPTION
This is a just in case change and shouldn't be merged.

We make use of a deprecated call in the NuGet libraries. This is a temporary, hacky, workaround in case there is any urgency to update them to a version without that method available. i.e. critical security update