### PR TITLE
Remove System.IO.Abstractions reference from test project

### DIFF
--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.2.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
System.IO.Abstractions.TestingHelpers brings in this dependency anyway. And this just causes Dependabot to trip up.