### PR TITLE
Fix incorrect floating behaviour

### DIFF
--- a/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
+++ b/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
@@ -27,7 +27,12 @@ namespace DotNetOutdated.Tests
                 new NuGetVersion("1.4.0-pre"),
                 new NuGetVersion("2.0.0"),
                 new NuGetVersion("2.1.0"),
-                new NuGetVersion("2.2.0-pre")
+                new NuGetVersion("2.2.0-pre.1"),
+                new NuGetVersion("2.2.0-pre.2"),
+                new NuGetVersion("3.0.0-pre.1"),
+                new NuGetVersion("3.0.0-pre.2"),
+                new NuGetVersion("3.1.0-pre.1"),
+                new NuGetVersion("4.0.0-pre.1")
             };
             
             var nuGetPackageInfoService = new Mock<INuGetPackageInfoService>();
@@ -35,15 +40,22 @@ namespace DotNetOutdated.Tests
                 .ReturnsAsync(availableVersions);
             
             _nuGetPackageResolutionService = new NuGetPackageResolutionService(nuGetPackageInfoService.Object);
-            }
+        }
 
         [Theory]
         [InlineData("1.2.0", VersionLock.None, PrereleaseReporting.Auto, "2.1.0")]
-        [InlineData("1.2.0", VersionLock.None, PrereleaseReporting.Always, "2.2.0-pre")]
-        [InlineData("1.3.0-pre", VersionLock.None, PrereleaseReporting.Auto, "2.2.0-pre")]
+        [InlineData("1.2.0", VersionLock.None, PrereleaseReporting.Always, "4.0.0-pre.1")]
+        [InlineData("1.3.0-pre", VersionLock.None, PrereleaseReporting.Auto, "4.0.0-pre.1")]
         [InlineData("1.3.0-pre", VersionLock.None, PrereleaseReporting.Never, "2.1.0")]
         [InlineData("1.2.0", VersionLock.Major, PrereleaseReporting.Auto, "1.3.0")]
         [InlineData("1.2.0", VersionLock.Minor, PrereleaseReporting.Auto, "1.2.2")]
+        [InlineData("3.0.0-pre.1", VersionLock.None, PrereleaseReporting.Never, "3.0.0-pre.1")]
+        [InlineData("3.0.0-pre.1", VersionLock.None, PrereleaseReporting.Always, "4.0.0-pre.1")]
+        [InlineData("3.0.0-pre.1", VersionLock.None, PrereleaseReporting.Auto, "4.0.0-pre.1")]
+        [InlineData("3.0.0-pre.1", VersionLock.Minor, PrereleaseReporting.Auto, "3.0.0-pre.2")]
+        [InlineData("3.0.0-pre.1", VersionLock.Minor, PrereleaseReporting.Always, "3.0.0-pre.2")]
+        [InlineData("3.0.0-pre.1", VersionLock.Major, PrereleaseReporting.Auto, "3.1.0-pre.1")]
+        [InlineData("3.0.0-pre.1", VersionLock.Major, PrereleaseReporting.Always, "3.1.0-pre.1")]
         public async Task ResolvesVersion_Correctly(string current, VersionLock versionLock, PrereleaseReporting prerelease, string latest)
         {
             // Arrange


### PR DESCRIPTION
While working on some automation built on top of `DotNetOutdatedTool.Core` I found that when locking the minor version, updates between .NET 6.0 previews were not being detected.

For example, with a Major or Minor lock, `6.0.0-preview.2.21154.6` does not correctly detect the upgrade to `6.0.0-preview.3.21201.13`. It works without a lock, but that isn't _technically_ what I want, as if there was a preview of 6.1 or 7.0 available concurrently, I wouldn't want either of those as the latest for my use case.

I'm fairly sure the first part of the fix is correct using the `NuGetVersionFloatBehavior` values that are specific to prereleases, but I'm not so sure about the second part. While it fixes my test case, it doesn't _feel_ correct.

Looking at the [code for `FloatRange`](https://github.com/NuGet/NuGet.Client/blob/1ef0444b1ff1ca79ebde7a6e3a717a4ff74b1832/src/NuGet.Core/NuGet.Versioning/FloatRange.cs#L116) it seems that if an explicit release prefix isn't provided, then it attempts to match it all (i.e. preview.2), so then no upgrade is detected. However if it is relaxed to `preview`, then it does.

One potential middleground for that would be to add another overload that allows the `releasePrefix` for the FloatingRange to be explicitly be provided by the caller.

/cc @slang25 
