### PR TITLE
fixes #68: skip packages with hard coded lower and upper bound

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -478,6 +478,12 @@ namespace DotNetOutdated
 
             if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion)
             {
+                if (dependency.VersionRange.HasLowerAndUpperBounds)
+                {
+                    // do nothing, only log somewhere?
+                    return;
+                }
+                
                 // special case when there is version installed which is not older than "OlderThan" days makes "latestVersion" to be null
                 if (OlderThanDays > 0 && latestVersion == null)
                 {


### PR DESCRIPTION
I might be thinking to simple, but when the package reference has both a lower and upper boundary, skip the dependency as an outdated one. (Still might be an option to log it, but don't 'just' update it without manual intervention.

I couldn't find any tests around this, might also be a good idea to add them for this situation.

In short I'd say: 
|#|Description|Result|
|---|---|---|
|1.|Package has lowerbound|Update it|
|2.|Package has upper bound|Don't update it|
|3.|Package has lower AND upper bound|Don't update it|

Only item 3 is fixed with this PR. If I am on the right way, I'd be happy to add the other checks as well.

