### PR TITLE
Add .NET 6 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 #
 # For an example commit browse to
 # https://github.com/dotnet-outdated/dotnet-outdated/commit/b9953b0ab06ac41206399f7ff7c593fa3201febc.
-# 
+#
 # The resulting release is here
 # https://github.com/dotnet-outdated/dotnet-outdated/releases/tag/v3.0.0.
 #
@@ -44,7 +44,12 @@ jobs:
         uses: actions/setup-dotnet@v1.8.2
         with:
           dotnet-version: '5.0.x'
-      
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+            dotnet-version: '6.0.x'
+
       # The tests should have already been run during the PR workflow, so this is really just a sanity check
       - name: Tests
         run: dotnet test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,6 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: '2.1.x'
-
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v1.8.2
-        with:
           dotnet-version: '3.1.x'
 
       - name: Setup dotnet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 #
 # For an example commit browse to
 # https://github.com/dotnet-outdated/dotnet-outdated/commit/b9953b0ab06ac41206399f7ff7c593fa3201febc.
-#
+# 
 # The resulting release is here
 # https://github.com/dotnet-outdated/dotnet-outdated/releases/tag/v3.0.0.
 #
@@ -46,10 +46,10 @@ jobs:
           dotnet-version: '5.0.x'
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v1.8.2
         with:
-            dotnet-version: '6.0.x'
-
+          dotnet-version: '6.0.x'    
+      
       # The tests should have already been run during the PR workflow, so this is really just a sanity check
       - name: Tests
         run: dotnet test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework: ['netcoreapp2.1', 'netcoreapp3.1', 'net5.0', 'net6.0']
+        framework: ['netcoreapp3.1', 'net5.0', 'net6.0']
     timeout-minutes: 30
     
     steps:
     - uses: actions/checkout@v2.3.5
-
-    - name: Setup dotnet
-      uses: actions/setup-dotnet@v1.8.2
-      with:
-        dotnet-version: '2.1.x'
 
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1.8.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   #   timeout-minutes: 30
   #   steps:
   #     - uses: actions/checkout@v2.3.5
-  
+
   #     - name: Build
   #       run: dotnet build /WarnAsError
 
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework: ['netcoreapp2.1', 'netcoreapp3.1', 'net5.0']
+        framework: ['netcoreapp2.1', 'netcoreapp3.1', 'net5.0', 'net6.0']
     timeout-minutes: 30
-    
+
     steps:
     - uses: actions/checkout@v2.3.5
 
@@ -39,6 +39,11 @@ jobs:
       uses: actions/setup-dotnet@v1.8.2
       with:
         dotnet-version: '5.0.x'
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1.8.2
+      with:
+        dotnet-version: '6.0.x'
 
     - name: Smoke test
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   #   timeout-minutes: 30
   #   steps:
   #     - uses: actions/checkout@v2.3.5
-
+  
   #     - name: Build
   #       run: dotnet build /WarnAsError
 
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         framework: ['netcoreapp2.1', 'netcoreapp3.1', 'net5.0', 'net6.0']
     timeout-minutes: 30
-
+    
     steps:
     - uses: actions/checkout@v2.3.5
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When using an IDE such as Visual Studio, it is easy to find out whether newer ve
 
 ## Installation
 
-Download and install the [.NET Core 2.1, 3.1, 5 or 6 SDK](https://www.microsoft.com/net/download). Once installed, run the following command:
+Download and install the [.NET Core 3.1, 5 or 6 SDK](https://www.microsoft.com/net/download). Once installed, run the following command:
 
 ```bash
 dotnet tool install --global dotnet-outdated-tool

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ When using an IDE such as Visual Studio, it is easy to find out whether newer ve
 
 **dotnet-outdated** is a .NET Core Global tool that allows you to quickly report on any outdated NuGet packages in your .NET Core and .NET Standard projects.
 
+- [dotnet-outdated](#dotnet-outdated)
+  - [Overview](#overview)
   - [Installation](#installation)
   - [Usage](#usage)
   - [Specifying the path](#specifying-the-path)
-- [Upgrading Packages](#upgrading-packages)
+  - [Upgrading packages](#upgrading-packages)
   - [Working with secure feeds](#working-with-secure-feeds)
+    - [Issues on macOS](#issues-on-macos)
   - [Handling pre-release versions](#handling-pre-release-versions)
   - [Locking to the current major or minor release](#locking-to-the-current-major-or-minor-release)
   - [Reporting on transitive dependencies](#reporting-on-transitive-dependencies)
@@ -29,7 +32,10 @@ When using an IDE such as Visual Studio, it is easy to find out whether newer ve
   - [Auto-references](#auto-references)
   - [Saving results to a file](#saving-results-to-a-file)
   - [Including and excluding packages](#including-and-excluding-packages)
+  - [Only listing new version of packages older than a specified the number of days](#only-listing-new-version-of-packages-older-than-a-specified-the-number-of-days)
   - [FAQ](#faq)
+    - [Why are unrelated changes made to .csproj files when running with `-u`?](#why-are-unrelated-changes-made-to-csproj-files-when-running-with--u)
+    - [Why I am getting an error about required library hostfxr.dll/libhostfxr.so/libhostfxr.dylib not found?](#why-i-am-getting-an-error-about-required-library-hostfxrdlllibhostfxrsolibhostfxrdylib-not-found)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,25 +17,19 @@ When using an IDE such as Visual Studio, it is easy to find out whether newer ve
 
 **dotnet-outdated** is a .NET Core Global tool that allows you to quickly report on any outdated NuGet packages in your .NET Core and .NET Standard projects.
 
-- [dotnet-outdated](#dotnet-outdated)
-  - [Overview](#overview)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [Specifying the path](#specifying-the-path)
-  - [Upgrading packages](#upgrading-packages)
-  - [Working with secure feeds](#working-with-secure-feeds)
-    - [Issues on macOS](#issues-on-macos)
-  - [Handling pre-release versions](#handling-pre-release-versions)
-  - [Locking to the current major or minor release](#locking-to-the-current-major-or-minor-release)
-  - [Reporting on transitive dependencies](#reporting-on-transitive-dependencies)
-  - [Failing when updates are available](#failing-when-updates-are-available)
-  - [Auto-references](#auto-references)
-  - [Saving results to a file](#saving-results-to-a-file)
-  - [Including and excluding packages](#including-and-excluding-packages)
-  - [Only listing new version of packages older than a specified the number of days](#only-listing-new-version-of-packages-older-than-a-specified-the-number-of-days)
-  - [FAQ](#faq)
-    - [Why are unrelated changes made to .csproj files when running with `-u`?](#why-are-unrelated-changes-made-to-csproj-files-when-running-with--u)
-    - [Why I am getting an error about required library hostfxr.dll/libhostfxr.so/libhostfxr.dylib not found?](#why-i-am-getting-an-error-about-required-library-hostfxrdlllibhostfxrsolibhostfxrdylib-not-found)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Specifying the path](#specifying-the-path)
+- [Upgrading Packages](#upgrading-packages)
+- [Working with secure feeds](#working-with-secure-feeds)
+- [Handling pre-release versions](#handling-pre-release-versions)
+- [Locking to the current major or minor release](#locking-to-the-current-major-or-minor-release)
+- [Reporting on transitive dependencies](#reporting-on-transitive-dependencies)
+- [Failing when updates are available](#failing-when-updates-are-available)
+- [Auto-references](#auto-references)
+- [Saving results to a file](#saving-results-to-a-file)
+- [Including and excluding packages](#including-and-excluding-packages)
+- [FAQ](#faq)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ When using an IDE such as Visual Studio, it is easy to find out whether newer ve
 
 **dotnet-outdated** is a .NET Core Global tool that allows you to quickly report on any outdated NuGet packages in your .NET Core and .NET Standard projects.
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Specifying the path](#specifying-the-path)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Specifying the path](#specifying-the-path)
 - [Upgrading Packages](#upgrading-packages)
-- [Working with secure feeds](#working-with-secure-feeds)
-- [Handling pre-release versions](#handling-pre-release-versions)
-- [Locking to the current major or minor release](#locking-to-the-current-major-or-minor-release)
-- [Reporting on transitive dependencies](#reporting-on-transitive-dependencies)
-- [Failing when updates are available](#failing-when-updates-are-available)
-- [Auto-references](#auto-references)
-- [Saving results to a file](#saving-results-to-a-file)
-- [Including and excluding packages](#including-and-excluding-packages)
-- [FAQ](#faq)
+  - [Working with secure feeds](#working-with-secure-feeds)
+  - [Handling pre-release versions](#handling-pre-release-versions)
+  - [Locking to the current major or minor release](#locking-to-the-current-major-or-minor-release)
+  - [Reporting on transitive dependencies](#reporting-on-transitive-dependencies)
+  - [Failing when updates are available](#failing-when-updates-are-available)
+  - [Auto-references](#auto-references)
+  - [Saving results to a file](#saving-results-to-a-file)
+  - [Including and excluding packages](#including-and-excluding-packages)
+  - [FAQ](#faq)
 
 ## Installation
 
-Download and install the [.NET Core 2.1, 3.1 or 5 SDK](https://www.microsoft.com/net/download). Once installed, run the following command:
+Download and install the [.NET Core 2.1, 3.1, 5 or 6 SDK](https://www.microsoft.com/net/download). Once installed, run the following command:
 
 ```bash
 dotnet tool install --global dotnet-outdated-tool

--- a/src/DotNetOutdated/DotNetOutdated.csproj
+++ b/src/DotNetOutdated/DotNetOutdated.csproj
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/dotnet-outdated/dotnet-outdated.git</RepositoryUrl>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />

--- a/src/DotNetOutdated/DotNetOutdated.csproj
+++ b/src/DotNetOutdated/DotNetOutdated.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>7.1</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-outdated</ToolCommandName>

--- a/src/DotNetOutdated/DotNetOutdated.csproj
+++ b/src/DotNetOutdated/DotNetOutdated.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>7.1</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-outdated</ToolCommandName>
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/dotnet-outdated/dotnet-outdated.git</RepositoryUrl>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Adding .NET 6 support as (on my machine anyway) homebrew only leaves the latest SDK/runtime combo for .NET installed and so I was getting the following error when trying to run dotnet outdated

```text
▲ project [master] dotnet outdated -u:prompt
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '5.0.0' (x64) was not found.
  - The following frameworks were found:
      6.0.0 at [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=5.0.0&arch=x64&rid=osx.11.0-x64
```
I followed the previous pull request #45 for when support for .NET 5 was added. 

This will close #216 
