### PR TITLE
Support PackageDownload

### DIFF
--- a/src/DotNetOutdated.Core/Models/Project.cs
+++ b/src/DotNetOutdated.Core/Models/Project.cs
@@ -46,13 +46,15 @@ namespace DotNetOutdated.Core.Models
 
         public bool IsTransitive { get; }
 
+        public bool IsDownloadDependency { get; }
+
         public string Name { get; }
 
         public NuGetVersion ResolvedVersion { get; }
 
         public VersionRange VersionRange { get; }
 
-        public Dependency(string name, VersionRange versionRange, NuGetVersion resolvedVersion, bool isAutoReferenced, bool isTransitive, bool isDevelopmentDependency)
+        public Dependency(string name, VersionRange versionRange, NuGetVersion resolvedVersion, bool isAutoReferenced, bool isTransitive, bool isDevelopmentDependency, bool isDownloadDependency = false)
         {
             Name = name;
             VersionRange = versionRange;
@@ -60,6 +62,7 @@ namespace DotNetOutdated.Core.Models
             IsAutoReferenced = isAutoReferenced;
             IsTransitive = isTransitive;
             IsDevelopmentDependency = isDevelopmentDependency;
+            IsDownloadDependency = isDownloadDependency;
         }
     }
 }

--- a/src/DotNetOutdated.Core/Services/DotNetAddPackageDownloadService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetAddPackageDownloadService.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.IO.Abstractions;
+using System.Xml;
+using NuGet.Versioning;
+
+namespace DotNetOutdated.Core.Services
+{
+    public class DotNetAddPackageDownloadService : IDotNetAddPackageService
+    {
+        private readonly IDotNetRunner _dotNetRunner;
+        private readonly IFileSystem _fileSystem;
+
+        public DotNetAddPackageDownloadService(IDotNetRunner dotNetRunner, IFileSystem fileSystem)
+        {
+            _dotNetRunner = dotNetRunner;
+            _fileSystem = fileSystem;
+        }
+
+        public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version)
+        {
+            return AddPackage(projectPath, packageName, frameworkName, version, false);
+        }
+
+        public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version, bool noRestore, bool ignoreFailedSource = false)
+        {
+            using (var stream = _fileSystem.FileStream.Create(projectPath, FileMode.Open, FileAccess.ReadWrite))
+            {
+                // Read xml from stream
+                var document = new XmlDocument();
+                document.Load(stream);
+
+                // Get PackageDownload element with matching package name
+                var packageDownloadElement = document.SelectSingleNode($"/Project/ItemGroup/PackageDownload[@Include='{packageName}']");
+
+                // Replace version of element with version from parameter
+                packageDownloadElement.Attributes["Version"].Value = $"[{version}]";
+
+                // Write xml back to stream
+                stream.Position = 0;
+                stream.SetLength(0);
+                document.Save(stream);
+            }
+
+            return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), new[] { "restore" });
+        }
+    }
+}

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -7,6 +7,7 @@ using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
+using NuGet.Versioning;
 
 namespace DotNetOutdated.Core.Services
 {
@@ -77,6 +78,13 @@ namespace DotNetOutdated.Core.Services
                             // Process transitive dependencies for the library
                             if (includeTransitiveDependencies)
                                 AddDependencies(targetFramework, projectLibrary, target, 1, transitiveDepth);
+                        }
+
+                        foreach (var downloadDependancy in targetFrameworkInformation.DownloadDependencies)
+                        {
+                            var dependency = new Dependency(downloadDependancy.Name, new VersionRange(downloadDependancy.VersionRange.MinVersion), downloadDependancy.VersionRange.MinVersion,
+                                false, false, true, true);
+                            targetFramework.Dependencies.Add(dependency);
                         }
                     }
                 }

--- a/src/DotNetOutdated/ConsolidatedPackage.cs
+++ b/src/DotNetOutdated/ConsolidatedPackage.cs
@@ -37,6 +37,8 @@ namespace DotNetOutdated
 
         public bool IsTransitive { get; set; }
 
+        public bool IsDownloadDependency { get; set; }
+
         public NuGetVersion LatestVersion { get; set; }
 
         public string Name { get; set; }

--- a/src/DotNetOutdated/Models/AnalyzedProject.cs
+++ b/src/DotNetOutdated/Models/AnalyzedProject.cs
@@ -69,6 +69,8 @@ namespace DotNetOutdated.Models
 
         public bool IsTransitive => _dependency.IsTransitive;
 
+        public bool IsDownloadDependency => _dependency.IsDownloadDependency;
+
         [JsonProperty(Order = 0)]
         public string Name => _dependency.Name;
 

--- a/src/DotNetOutdated/ProjectExtensions.cs
+++ b/src/DotNetOutdated/ProjectExtensions.cs
@@ -23,6 +23,7 @@ namespace DotNetOutdated
                     LatestVersion = d.LatestVersion,
                     IsAutoReferenced = d.IsAutoReferenced,
                     IsTransitive = d.IsTransitive,
+                    IsDownloadDependency = d.IsDownloadDependency,
                     UpgradeSeverity = d.UpgradeSeverity
                 };
 
@@ -34,6 +35,7 @@ namespace DotNetOutdated
                     p.LatestVersion,
                     p.IsTransitive,
                     p.IsAutoReferenced,
+                    p.IsDownloadDependency,
                     p.UpgradeSeverity
                 })
                 .Select(gp => new ConsolidatedPackage
@@ -43,6 +45,7 @@ namespace DotNetOutdated
                     LatestVersion = gp.Key.LatestVersion,
                     IsTransitive = gp.Key.IsTransitive,
                     IsAutoReferenced = gp.Key.IsAutoReferenced,
+                    IsDownloadDependency = gp.Key.IsDownloadDependency,
                     UpgradeSeverity = gp.Key.UpgradeSeverity,
                     Projects = gp.Select(v => new ConsolidatedPackage.PackageProjectReference
                     {


### PR DESCRIPTION
PackageDownload is an obscure feature which is used a lot by NUKE builds. I've implemented the detection of download dependencies which wasn't that hard because it's completely supported by NuGet. But the dotnet tooling support isn't that great which makes upgrading harder so I had to workaround that by manually editing the csproj.
Would like to hear your feedback if you think this could be done better or differently.