### PR TITLE
Improve GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,32 +30,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3.3.0
 
-      - name: Setup dotnet
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: '6.0.x'
-
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v3.0.3
-        with:
-          dotnet-version: '7.0.x'
+          dotnet-version: | 
+            6.0.x
+            7.0.x
 
       # The tests should have already been run during the PR workflow, so this is really just a sanity check
       - name: Tests
-        run: dotnet test
+        run: dotnet test --configuration Release
 
       - name: Package release
         id: package_release
         run: |
           VERSION=`cat semver.txt`
           OUTPUT=./nupkgs
-          echo "##[set-output name=version;]$VERSION"
-          echo "##[set-output name=core_package_name;]DotNetOutdatedTool.Core.$VERSION.nupkg"
-          echo "##[set-output name=core_package_filename;]$OUTPUT/DotNetOutdatedTool.Core.$VERSION.nupkg"
-          echo "##[set-output name=tool_package_name;]dotnet-outdated-tool.$VERSION.nupkg"
-          echo "##[set-output name=tool_package_filename;]$OUTPUT/dotnet-outdated-tool.$VERSION.nupkg"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "core_package_name=DotNetOutdatedTool.Core.$VERSION.nupkg" >> $GITHUB_OUTPUT
+          echo "core_package_filename=$OUTPUT/DotNetOutdatedTool.Core.$VERSION.nupkg" >> $GITHUB_OUTPUT
+          echo "tool_package_name=dotnet-outdated-tool.$VERSION.nupkg" >> $GITHUB_OUTPUT
+          echo "tool_package_filename=$OUTPUT/dotnet-outdated-tool.$VERSION.nupkg" >> $GITHUB_OUTPUT
           dotnet build --configuration Release
-          dotnet pack --configuration Release /p:Version=$VERSION --output $OUTPUT
+          dotnet pack --configuration Release /p:Version=$VERSION /p:PackageOutputPath $OUTPUT
 
       - name: Publish package
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,19 +25,16 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@v3.0.3
       with:
-        dotnet-version: '6.0.x'
-
-    - name: Setup dotnet
-      uses: actions/setup-dotnet@v3.0.3
-      with:
-        dotnet-version: '7.0.x'
+        dotnet-version: | 
+            6.0.x
+            7.0.x
 
     - name: Smoke test
       run: |
-        dotnet run --framework ${{ matrix.framework }} --project src/DotNetOutdated test-projects/development-dependencies
+        dotnet run --configuration Release --framework ${{ matrix.framework }} --project src/DotNetOutdated test-projects/development-dependencies
 
     - name: Tests
-      run: dotnet test --framework ${{ matrix.framework }}
+      run: dotnet test --configuration Release --framework ${{ matrix.framework }}


### PR DESCRIPTION
- Fix [`NETSDK1194` error](https://github.com/dotnet-outdated/dotnet-outdated/actions/runs/4285623458/jobs/7464148984#step:6:45) from .NET 7.0.2xx SDK.
- Fix `set-output` deprecation warnings.
- Only run `actions/setup-dotnet` once.
- Specify `--configuration Release`.
