### PR TITLE
Fix compiler warning

### DIFF
--- a/src/DotNetOutdated/Formatters/JsonFormatter.cs
+++ b/src/DotNetOutdated/Formatters/JsonFormatter.cs
@@ -21,7 +21,7 @@ internal class JsonFormatter : IOutputFormatter
 
     private class Report
     {
-        public IReadOnlyList<AnalyzedProject>? Projects { get; set; }
+        public IReadOnlyList<AnalyzedProject> Projects { get; set; }
 
         internal static string GetTextReportLine(AnalyzedProject project, AnalyzedTargetFramework targetFramework, AnalyzedDependency dependency)
         {


### PR DESCRIPTION
Fix `The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.`.
