### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: package_release
         run: |
           VERSION=`cat semver.txt`
-          OUTPUT=./nupkgs
+          OUTPUT=${{ runner.temp }}/nupkgs
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "core_package_name=DotNetOutdatedTool.Core.$VERSION.nupkg" >> $GITHUB_OUTPUT
           echo "core_package_filename=$OUTPUT/DotNetOutdatedTool.Core.$VERSION.nupkg" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The PR addresses the broken release workflow. This is due to `PackageOutputPath` working differently with relative paths and absolute ones