### PR TITLE
#344 Added parameter --all to list all dependencies including the ones that do not need upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Options:
   -n|--no-restore                            Add the reference without performing restore preview and compatibility check.
   -r|--recursive                             Recursively search for all projects within the provided directory.
   -ifs|--ignore-failed-sources               Treat package source failures as warnings.
+  -utd|--include-up-to-date                  Include all dependencies in the report even the ones not outdated.
 ```
 
 ![Screenshot of dotnet-outdated](screenshot.png)

--- a/src/DotNetOutdated/Models/AnalyzedProject.cs
+++ b/src/DotNetOutdated/Models/AnalyzedProject.cs
@@ -103,11 +103,6 @@ namespace DotNetOutdated.Models
             }
         }
 
-        [JsonProperty(Order = 4)]
-        public bool IsOutdated => _dependency.ResolvedVersion == null ||
-                                  LatestVersion == null ||
-                                  _dependency.ResolvedVersion < LatestVersion;
-
         public AnalyzedDependency(Dependency dependency)
         {
             _dependency = dependency;

--- a/src/DotNetOutdated/Models/AnalyzedProject.cs
+++ b/src/DotNetOutdated/Models/AnalyzedProject.cs
@@ -103,6 +103,11 @@ namespace DotNetOutdated.Models
             }
         }
 
+        [JsonProperty(Order = 4)]
+        public bool IsOutdated => _dependency.ResolvedVersion == null ||
+                                  LatestVersion == null ||
+                                  _dependency.ResolvedVersion < LatestVersion;
+
         public AnalyzedDependency(Dependency dependency)
         {
             _dependency = dependency;

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -108,9 +108,9 @@ namespace DotNetOutdated
         [Option(CommandOptionType.NoValue, Description = "Treat package source failures as warnings.", ShortName = "ifs", LongName = "ignore-failed-sources")]
         public bool IgnoreFailedSources { get; set; } = false;
 
-        [Option(CommandOptionType.NoValue, Description = "Include all dependencies in the report even the ones not outdated",
-            ShortName = "a", LongName = "all")]
-        public bool All { get; set; } = false;
+        [Option(CommandOptionType.NoValue, Description = "Include all dependencies in the report even the ones not outdated.",
+            ShortName = "utd", LongName = "include-up-to-date")]
+        public bool IncludeUpToDate { get; set; } = false;
 
         public static int Main(string[] args)
         {
@@ -492,7 +492,7 @@ namespace DotNetOutdated
                     VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency, OlderThanDays, IgnoreFailedSources).ConfigureAwait(false);
             }
 
-            if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion || All)
+            if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion || IncludeUpToDate)
             {
                 // special case when there is version installed which is not older than "OlderThan" days makes "latestVersion" to be null
                 if (OlderThanDays > 0 && latestVersion == null)

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -500,7 +500,7 @@ namespace DotNetOutdated
                     NuGetVersion absoluteLatestVersion = await _nugetService.ResolvePackageVersions(dependency.Name, referencedVersion, project.Sources, dependency.VersionRange,
                         VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency).ConfigureAwait(false);
 
-                    if (absoluteLatestVersion == null || referencedVersion > absoluteLatestVersion || All)
+                    if (absoluteLatestVersion == null || referencedVersion > absoluteLatestVersion)
                     {
                         outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion));
                     }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -315,7 +315,7 @@ namespace DotNetOutdated
         public static void WriteColoredUpgrade(DependencyUpgradeSeverity? upgradeSeverity, NuGetVersion resolvedVersion, NuGetVersion latestVersion, int resolvedWidth, int latestWidth, IConsole console)
         {
             console.Write((resolvedVersion?.ToString() ?? "").PadRight(resolvedWidth));
-            console.Write(" -> ");
+            console.Write(resolvedVersion?.Equals(latestVersion) ?? false ? " == " : " -> ");
 
             // Exit early to avoid having to handle nulls later
             if (latestVersion == null)

--- a/test/DotNetOutdated.Tests/VersionNumberColoringTests.cs
+++ b/test/DotNetOutdated.Tests/VersionNumberColoringTests.cs
@@ -79,5 +79,22 @@ namespace DotNetOutdated.Tests
             var secondDot = latest.IndexOf(".", latest.IndexOf(".", System.StringComparison.Ordinal) + 1, System.StringComparison.Ordinal) + 1;
             Assert.Equal($"{resolved} -> {latest[..secondDot]}[Green]{latest[secondDot..]}[White]", console.WrittenOut);
         }
+
+        [Theory]
+        [InlineData("1.2.3    ", "1.2.3    ")]
+        [InlineData("2.0.0    ", "2.0.0    ")]
+        public void NoColors(string resolved, string latest)
+        {
+            ArgumentNullException.ThrowIfNull(resolved);
+            ArgumentNullException.ThrowIfNull(latest);
+
+            var resolvedVersion = new NuGetVersion(resolved);
+            var latestVersion = new NuGetVersion(latest);
+
+            using var console = new MockConsole();
+
+            Program.WriteColoredUpgrade(DependencyUpgradeSeverity.None, resolvedVersion, latestVersion, 9, 9, console);
+            Assert.Equal($"{resolved} -> {latest}", console.WrittenOut);
+        }
     }
 }

--- a/test/DotNetOutdated.Tests/VersionNumberColoringTests.cs
+++ b/test/DotNetOutdated.Tests/VersionNumberColoringTests.cs
@@ -94,7 +94,7 @@ namespace DotNetOutdated.Tests
             using var console = new MockConsole();
 
             Program.WriteColoredUpgrade(DependencyUpgradeSeverity.None, resolvedVersion, latestVersion, 9, 9, console);
-            Assert.Equal($"{resolved} -> {latest}", console.WrittenOut);
+            Assert.Equal($"{resolved} == {latest}", console.WrittenOut);
         }
     }
 }


### PR DESCRIPTION
Added support for a command line parameter --all to list all dependencies including the ones that do not need upgrades as detailed in #344

Example

```bash
dotnet-outdated.exe -t --all
» aspnettest
  [net7.0]
  Microsoft.AspNetCore.OpenApi                    7.0.8 == 7.0.8
  Microsoft.Extensions.ApiDescription.Server [T]  6.0.5 -> 7.0.8
  Microsoft.OpenApi [T]                           1.4.3 -> 1.6.5
  Swashbuckle.AspNetCore                          6.4.0 -> 6.5.0
  Swashbuckle.AspNetCore.Swagger [T]              6.4.0 -> 6.5.0
  Swashbuckle.AspNetCore.SwaggerGen [T]           6.4.0 -> 6.5.0
  Swashbuckle.AspNetCore.SwaggerUI [T]            6.4.0 -> 6.5.0

Version color legend:
<red>   : Major version update or pre-release version. Possible breaking changes.
<yellow>: Minor version update. Backwards-compatible features added.
<green> : Patch version update. Backwards-compatible bug fixes.

You can upgrade packages to the latest version by passing the -u or -u:prompt option.
Elapsed: 00:00:01.7981915
```