### PR TITLE
Support variable release prefix lengths

### DIFF
--- a/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
@@ -1,19 +1,37 @@
-﻿using NuGet.Frameworks;
-using NuGet.Versioning;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NuGet.Frameworks;
+using NuGet.Versioning;
 
 namespace DotNetOutdated.Core.Services
 {
     public interface INuGetPackageResolutionService
     {
-        Task<NuGetVersion> ResolvePackageVersions(string packageName,
-            NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
-            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency);
+        Task<NuGetVersion> ResolvePackageVersions(
+            string packageName,
+            NuGetVersion referencedVersion,
+            IEnumerable<Uri> sources,
+            VersionRange currentVersionRange,
+            VersionLock versionLock,
+            PrereleaseReporting prerelease,
+            string prereleaseLabel,
+            NuGetFramework targetFrameworkName,
+            string projectFilePath,
+            bool isDevelopmentDependency);
 
-        Task<NuGetVersion> ResolvePackageVersions(string packageName,
-            NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
-            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays, bool ignoreFailedSources);
+        Task<NuGetVersion> ResolvePackageVersions(
+            string packageName,
+            NuGetVersion referencedVersion,
+            IEnumerable<Uri> sources,
+            VersionRange currentVersionRange,
+            VersionLock versionLock,
+            PrereleaseReporting prerelease,
+            string prereleaseLabel,
+            NuGetFramework targetFrameworkName,
+            string projectFilePath,
+            bool isDevelopmentDependency,
+            int olderThanDays,
+            bool ignoreFailedSources);
     }
 }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -112,6 +112,11 @@ namespace DotNetOutdated
             ShortName = "utd", LongName = "include-up-to-date")]
         public bool IncludeUpToDate { get; set; } = false;
 
+        [Option(CommandOptionType.SingleValue, Description = "Specifies an optional label to restrict matches to when looking for pre-release versions of packages. " +
+                                                             "For example, a label of 'rc.1' would only match pre-release packages with a pre-release label that starts with that prefix.",
+            ShortName = "prl", LongName = "pre-release-label")]
+        public string PrereleaseLabel { get; set; } = string.Empty;
+
         public static int Main(string[] args)
         {
             using var services = new ServiceCollection()
@@ -488,8 +493,19 @@ namespace DotNetOutdated
 
             if (referencedVersion != null)
             {
-                latestVersion = await _nugetService.ResolvePackageVersions(dependency.Name, referencedVersion, project.Sources, dependency.VersionRange,
-                    VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency, OlderThanDays, IgnoreFailedSources).ConfigureAwait(false);
+                latestVersion = await _nugetService.ResolvePackageVersions(
+                    dependency.Name,
+                    referencedVersion,
+                    project.Sources,
+                    dependency.VersionRange,
+                    VersionLock,
+                    Prerelease,
+                    PrereleaseLabel,
+                    targetFramework.Name,
+                    project.FilePath,
+                    dependency.IsDevelopmentDependency,
+                    OlderThanDays,
+                    IgnoreFailedSources).ConfigureAwait(false);
             }
 
             if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion || IncludeUpToDate)
@@ -497,8 +513,17 @@ namespace DotNetOutdated
                 // special case when there is version installed which is not older than "OlderThan" days makes "latestVersion" to be null
                 if (OlderThanDays > 0 && latestVersion == null)
                 {
-                    NuGetVersion absoluteLatestVersion = await _nugetService.ResolvePackageVersions(dependency.Name, referencedVersion, project.Sources, dependency.VersionRange,
-                        VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency).ConfigureAwait(false);
+                    NuGetVersion absoluteLatestVersion = await _nugetService.ResolvePackageVersions(
+                        dependency.Name,
+                        referencedVersion,
+                        project.Sources,
+                        dependency.VersionRange,
+                        VersionLock,
+                        Prerelease,
+                        PrereleaseLabel,
+                        targetFramework.Name,
+                        project.FilePath,
+                        dependency.IsDevelopmentDependency).ConfigureAwait(false);
 
                     if (absoluteLatestVersion == null || referencedVersion > absoluteLatestVersion)
                     {

--- a/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
+++ b/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
@@ -1,11 +1,11 @@
-﻿using DotNetOutdated.Core;
-using DotNetOutdated.Core.Services;
-using NuGet.Frameworks;
-using NuGet.Versioning;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DotNetOutdated.Core;
+using DotNetOutdated.Core.Services;
 using NSubstitute;
+using NuGet.Frameworks;
+using NuGet.Versioning;
 using Xunit;
 
 namespace DotNetOutdated.Tests
@@ -83,50 +83,44 @@ namespace DotNetOutdated.Tests
         [InlineData("3.0.0-pre.1", VersionLock.Major, PrereleaseReporting.Always, "3.1.0-pre.1")]
         public async Task ResolvesVersionCorrectly(string current, VersionLock versionLock, PrereleaseReporting prerelease, string latest)
         {
-            // Arrange
-            _nuGetPackageResolutionService.PrereleaseLabelPartsValue = null;
-
             // Act
-            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName1, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
+            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName1, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, null, false, 0);
 
             // Assert
             Assert.Equal(NuGetVersion.Parse(latest), latestVersion);
         }
 
         [Theory]
-        [InlineData("3.0.0", VersionLock.None, PrereleaseReporting.Auto, 1, "7.0.1")]
-        [InlineData("3.0.0", VersionLock.None, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Never, 1, "8.0.0-preview.1.123")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Never, 2, "8.0.0-preview.1.123")]
-        [InlineData("3.0.0", VersionLock.Major, PrereleaseReporting.Auto, 1, "3.1.1")]
-        [InlineData("3.0.0", VersionLock.Minor, PrereleaseReporting.Auto, 1, "3.0.1")]
-        [InlineData("3.1.0", VersionLock.Minor, PrereleaseReporting.Auto, 1, "3.1.1")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 2, "8.0.0-rc.2.128")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 1, "8.0.0-rc.2.128")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 2, "8.0.0-rc.2.128")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Auto, 1, "3.1.1")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Always, 1, "3.1.1")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.Major, PrereleaseReporting.Auto, 1, "3.1.1")]
-        [InlineData("3.1.0-preview.1.123", VersionLock.Major, PrereleaseReporting.Always, 1, "3.1.1")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 2, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 1, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 2, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Auto, 1, "8.0.0-preview.3.126")]
-        [InlineData("8.0.0-preview.3.126", VersionLock.Minor, PrereleaseReporting.Always, 1, "8.0.0-preview.3.126")]
-        [InlineData("8.0.0-preview.3.126", VersionLock.Minor, PrereleaseReporting.Always, 2, "8.0.0-preview.3.126")]
-        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Auto, 1, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Auto, 2, "8.0.0-rc.1.127")]
-        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
-        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Always, 2, "8.0.0-rc.1.127")]
-        public async Task ResolvesVersionCorrectlyWithParts(string current, VersionLock versionLock, PrereleaseReporting prerelease, int parts, string latest)
+        [InlineData("3.0.0", VersionLock.None, PrereleaseReporting.Auto, null, "7.0.1")]
+        [InlineData("3.0.0", VersionLock.None, PrereleaseReporting.Always, null, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Never, null, "8.0.0-preview.1.123")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Never, "preview.1", "8.0.0-preview.1.123")]
+        [InlineData("3.0.0", VersionLock.Major, PrereleaseReporting.Auto, null, "3.1.1")]
+        [InlineData("3.0.0", VersionLock.Minor, PrereleaseReporting.Auto, null, "3.0.1")]
+        [InlineData("3.1.0", VersionLock.Minor, PrereleaseReporting.Auto, null, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, null, "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, "rc.2", "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, null, "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, "rc.2", "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Auto, null, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Always, null, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Major, PrereleaseReporting.Auto, null, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Major, PrereleaseReporting.Always, null, "3.1.1")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, null, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, "rc.2", "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, null, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, "rc.2", "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Auto, null, "8.0.0-preview.3.126")]
+        [InlineData("8.0.0-preview.3.126", VersionLock.Minor, PrereleaseReporting.Always, null, "8.0.0-preview.3.126")]
+        [InlineData("8.0.0-preview.3.126", VersionLock.Minor, PrereleaseReporting.Always, "preview.3", "8.0.0-preview.3.126")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Auto, null, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Auto, "rc.1", "8.0.0-rc.1.127")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Always, null, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Always, "rc.1", "8.0.0-rc.1.127")]
+        public async Task ResolvesVersionCorrectlyWithParts(string current, VersionLock versionLock, PrereleaseReporting prerelease, string prereleaseLabel, string latest)
         {
-            // Arrange
-            _nuGetPackageResolutionService.PrereleaseLabelPartsValue = parts;
-
             // Act
-            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName2, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
+            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName2, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, prereleaseLabel, null, null, false, 0);
 
             // Assert
             Assert.Equal(NuGetVersion.Parse(latest), latestVersion);

--- a/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
+++ b/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
@@ -12,12 +12,13 @@ namespace DotNetOutdated.Tests
 {
     public class NuGetPackageResolutionServiceTests
     {
-        private readonly string _packageName = "MyPackage";
+        private readonly string _packageName1 = "MyPackage";
+        private readonly string _packageName2 = "YourPackage";
         private readonly NuGetPackageResolutionService _nuGetPackageResolutionService;
 
         public NuGetPackageResolutionServiceTests()
         {
-            List<NuGetVersion> availableVersions = new()
+            List<NuGetVersion> availableVersions1 = new()
             {
                 new NuGetVersion("1.1.0"),
                 new NuGetVersion("1.2.0"),
@@ -32,12 +33,36 @@ namespace DotNetOutdated.Tests
                 new NuGetVersion("3.0.0-pre.1"),
                 new NuGetVersion("3.0.0-pre.2"),
                 new NuGetVersion("3.1.0-pre.1"),
-                new NuGetVersion("4.0.0-pre.1")
+                new NuGetVersion("4.0.0-pre.1"),
+            };
+
+            List<NuGetVersion> availableVersions2 = new()
+            {
+                new NuGetVersion("3.0.0-preview.1.123"),
+                new NuGetVersion("3.0.0"),
+                new NuGetVersion("3.0.1"),
+                new NuGetVersion("3.1.0-preview.1.123"),
+                new NuGetVersion("3.1.0"),
+                new NuGetVersion("3.1.1-preview.1.123"),
+                new NuGetVersion("3.1.1"),
+                new NuGetVersion("6.0.0-preview.1.123"),
+                new NuGetVersion("6.0.0"),
+                new NuGetVersion("6.0.1"),
+                new NuGetVersion("7.0.0"),
+                new NuGetVersion("7.0.1"),
+                new NuGetVersion("8.0.0-preview.1.123"),
+                new NuGetVersion("8.0.0-preview.1.124"),
+                new NuGetVersion("8.0.0-preview.2.125"),
+                new NuGetVersion("8.0.0-preview.3.126"),
+                new NuGetVersion("8.0.0-rc.1.127"),
+                new NuGetVersion("8.0.0-rc.2.128"),
             };
 
             var nuGetPackageInfoService = Substitute.For<INuGetPackageInfoService>();
-            nuGetPackageInfoService.GetAllVersions(_packageName, Arg.Any<List<Uri>>(), Arg.Any<bool>(), Arg.Any<NuGetFramework>(), Arg.Any<string>(), Arg.Any<bool>(), 0, Arg.Any<bool>())
-                .Returns(availableVersions);
+            nuGetPackageInfoService.GetAllVersions(_packageName1, Arg.Any<List<Uri>>(), Arg.Any<bool>(), Arg.Any<NuGetFramework>(), Arg.Any<string>(), Arg.Any<bool>(), 0, Arg.Any<bool>())
+                .Returns(availableVersions1);
+            nuGetPackageInfoService.GetAllVersions(_packageName2, Arg.Any<List<Uri>>(), Arg.Any<bool>(), Arg.Any<NuGetFramework>(), Arg.Any<string>(), Arg.Any<bool>(), 0, Arg.Any<bool>())
+                .Returns(availableVersions2);
 
             _nuGetPackageResolutionService = new NuGetPackageResolutionService(nuGetPackageInfoService);
         }
@@ -59,9 +84,49 @@ namespace DotNetOutdated.Tests
         public async Task ResolvesVersionCorrectly(string current, VersionLock versionLock, PrereleaseReporting prerelease, string latest)
         {
             // Arrange
+            _nuGetPackageResolutionService.PrereleaseLabelPartsValue = null;
 
             // Act
-            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
+            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName1, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
+
+            // Assert
+            Assert.Equal(NuGetVersion.Parse(latest), latestVersion);
+        }
+
+        [Theory]
+        [InlineData("3.0.0", VersionLock.None, PrereleaseReporting.Auto, 1, "7.0.1")]
+        [InlineData("3.0.0", VersionLock.None, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Never, 1, "8.0.0-preview.1.123")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Never, 2, "8.0.0-preview.1.123")]
+        [InlineData("3.0.0", VersionLock.Major, PrereleaseReporting.Auto, 1, "3.1.1")]
+        [InlineData("3.0.0", VersionLock.Minor, PrereleaseReporting.Auto, 1, "3.0.1")]
+        [InlineData("3.1.0", VersionLock.Minor, PrereleaseReporting.Auto, 1, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 2, "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 1, "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 2, "8.0.0-rc.2.128")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Auto, 1, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Always, 1, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Major, PrereleaseReporting.Auto, 1, "3.1.1")]
+        [InlineData("3.1.0-preview.1.123", VersionLock.Major, PrereleaseReporting.Always, 1, "3.1.1")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Always, 2, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 1, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.None, PrereleaseReporting.Auto, 2, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-preview.1.123", VersionLock.Minor, PrereleaseReporting.Auto, 1, "8.0.0-preview.3.126")]
+        [InlineData("8.0.0-preview.3.126", VersionLock.Minor, PrereleaseReporting.Always, 1, "8.0.0-preview.3.126")]
+        [InlineData("8.0.0-preview.3.126", VersionLock.Minor, PrereleaseReporting.Always, 2, "8.0.0-preview.3.126")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Auto, 1, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Auto, 2, "8.0.0-rc.1.127")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Always, 1, "8.0.0-rc.2.128")]
+        [InlineData("8.0.0-rc.1.127", VersionLock.Major, PrereleaseReporting.Always, 2, "8.0.0-rc.1.127")]
+        public async Task ResolvesVersionCorrectlyWithParts(string current, VersionLock versionLock, PrereleaseReporting prerelease, int parts, string latest)
+        {
+            // Arrange
+            _nuGetPackageResolutionService.PrereleaseLabelPartsValue = parts;
+
+            // Act
+            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName2, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
 
             // Assert
             Assert.Equal(NuGetVersion.Parse(latest), latestVersion);


### PR DESCRIPTION
Support allowing for a variable number of parts for a release label prefix to support the scenario of not moving between .NET preview releases.

The motivation here is that if I'm testing prerelease versions of the next preview of .NET 8, I want the NuGet packages updates to remain within the same preview version and not pick up packages from the preview after that.

For instance, with the current behaviour I get this output:

```
> dotnet outdated --no-restore --version-lock Minor --include Microsoft.AspNetCore.
» Project
  [net8.0]
  Microsoft.AspNetCore.Authentication.JwtBearer   8.0.0-rc.1.23416.4 -> 8.0.0-rc.2.23417.18
  Microsoft.AspNetCore.DataProtection.Extensions  8.0.0-rc.1.23416.4 -> 8.0.0-rc.2.23417.18

» Project.Tests
  [net8.0]
  Microsoft.AspNetCore.Mvc.Testing  8.0.0-rc.1.23416.4 -> 8.0.0-rc.2.23417.18
```

With the changes in this PR and `DOTNET_OUTDATED_PRERELEASE_LABEL_PARTS` set to `2` I get this output, which is the behaviour I want:

```
> dotnet outdated --no-restore --version-lock Minor --include Microsoft.AspNetCore.
» Project
  [net8.0]
  Microsoft.AspNetCore.Authentication.JwtBearer   8.0.0-rc.1.23416.4 -> 8.0.0-rc.1.23417.11
  Microsoft.AspNetCore.DataProtection.Extensions  8.0.0-rc.1.23416.4 -> 8.0.0-rc.1.23417.11

» Project.Tests
  [net8.0]
  Microsoft.AspNetCore.Mvc.Testing  8.0.0-rc.1.23416.4 -> 8.0.0-rc.1.23417.11
```

This is currently just a draft as:

1. It uses an environment variable for the override. A command line flag would be better, but then trying to pass the value through requires breaking API surface changes.
2. I have no idea what the concept I'm trying to make configurable here is.
3. Is there a reasonable way to auto-infer this behaviour based on the prerelease label on the package anyway and not require any input at all? If there is, that would be better.

The PR itself at this stage is just enough changes to demonstrate the use case.
