### PR TITLE
feat: Allow to generate more than one output at once

### DIFF
--- a/src/DotNetOutdated/Formatters/CsvFormatter.cs
+++ b/src/DotNetOutdated/Formatters/CsvFormatter.cs
@@ -1,15 +1,23 @@
 ﻿using CsvHelper;
 using DotNetOutdated.Models;
+using McMaster.Extensions.CommandLineUtils;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Abstractions;
 
 namespace DotNetOutdated.Formatters;
 
-internal class CsvFormatter : IOutputFormatter
+internal class CsvFormatter : FileFormatter
 {
-    public void Format(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
+    public CsvFormatter(IFileSystem fileSystem, IConsole console) : base(fileSystem, console)
+    {
+    }
+
+    protected override string Extension => ".csv";
+
+    protected override void Format(IReadOnlyList<AnalyzedProject> projects, IDictionary<string, string> options, TextWriter writer)
     {
         using var csv = new CsvWriter(writer, CultureInfo.CurrentCulture);
         foreach (var project in projects)
@@ -33,6 +41,5 @@ internal class CsvFormatter : IOutputFormatter
                 }
             }
         }
-
     }
 }

--- a/src/DotNetOutdated/Formatters/FileFormatter.cs
+++ b/src/DotNetOutdated/Formatters/FileFormatter.cs
@@ -1,0 +1,53 @@
+﻿using DotNetOutdated.Models;
+using McMaster.Extensions.CommandLineUtils;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+
+namespace DotNetOutdated.Formatters;
+
+/// <summary>
+/// <see cref="FileFormatter"/> is base class for format that should write on fileSystem
+/// </summary>
+internal abstract class FileFormatter : IOutputFormatter
+{
+    private readonly IFileSystem _fileSystem;
+
+    public FileFormatter(IFileSystem fileSystem, IConsole console)
+    {
+        _fileSystem = fileSystem;
+        Console = console;
+    }
+
+    protected IConsole Console { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="projects"></param>
+    /// <param name="options"></param>
+    public void Format(IReadOnlyList<AnalyzedProject> projects, IDictionary<string, string> options)
+    {
+        Console.WriteLine();
+        Console.Write($"Generating {GetType().Name.Replace("Formatter", "", System.StringComparison.OrdinalIgnoreCase).ToLowerInvariant()} report ...");
+        if (options.TryGetValue("outputFile", out var outputFile))
+        {
+            outputFile = _fileSystem.Path.ChangeExtension(outputFile, Extension);
+            using var stream = _fileSystem.File.Create(outputFile);
+            using var sw = new StreamWriter(stream);
+            Format(projects, options, sw);
+        }
+        else
+        {
+            Console.WriteLine();
+            Console.Error.Write("Output file option not set.", Constants.ReportingColors.Error);
+            Console.WriteLine();
+        }
+    }
+
+    protected abstract void Format(IReadOnlyList<AnalyzedProject> projects
+        , IDictionary<string, string> options
+        , TextWriter writer);
+
+    protected abstract string Extension { get; }
+}

--- a/src/DotNetOutdated/Formatters/JsonFormatter.cs
+++ b/src/DotNetOutdated/Formatters/JsonFormatter.cs
@@ -1,15 +1,23 @@
 ﻿using DotNetOutdated.Models;
+using McMaster.Extensions.CommandLineUtils;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Abstractions;
 
 namespace DotNetOutdated.Formatters;
 
-internal class JsonFormatter : IOutputFormatter
+internal class JsonFormatter : FileFormatter
 {
-    public void Format(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
+    public JsonFormatter(IFileSystem fileSystem, IConsole console) : base(fileSystem, console)
+    {
+    }
+
+    protected override string Extension => ".json";
+
+    protected override void Format(IReadOnlyList<AnalyzedProject> projects, IDictionary<string, string> options, TextWriter writer)
     {
         var report = new Report
         {

--- a/src/DotNetOutdated/Formatters/MarkdownFormatter.cs
+++ b/src/DotNetOutdated/Formatters/MarkdownFormatter.cs
@@ -1,13 +1,15 @@
 ﻿#nullable enable
 using DotNetOutdated.Models;
+using McMaster.Extensions.CommandLineUtils;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace DotNetOutdated.Formatters;
 
-internal class MarkdownFormatter : IOutputFormatter
+internal class MarkdownFormatter : FileFormatter
 {
     static readonly Dictionary<DependencyUpgradeSeverity, string?> _colorMaps = new()
     {
@@ -18,11 +20,17 @@ internal class MarkdownFormatter : IOutputFormatter
         {DependencyUpgradeSeverity.Unknown,default},
     };
 
-    public void Format(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
+    protected override string Extension => ".md";
+
+    public MarkdownFormatter(IFileSystem fileSystem, IConsole console) : base(fileSystem, console)
+    {
+    }
+
+    protected override void Format(IReadOnlyList<AnalyzedProject> projects, IDictionary<string, string> options, TextWriter writer)
     {
         writer.WriteLine("# Outdated Packages");
         writer.WriteLine();
-        foreach (var project in projects.OrderBy(p=>p.Name))
+        foreach (var project in projects.OrderBy(p => p.Name))
         {
             writer.WriteLine($"## {project.Name}");
             writer.WriteLine();

--- a/src/DotNetOutdated/IOutputFormatter.cs
+++ b/src/DotNetOutdated/IOutputFormatter.cs
@@ -4,7 +4,9 @@ using System.IO;
 
 namespace DotNetOutdated;
 
+internal delegate bool OutputFormatterFactory(string name, out IOutputFormatter formatter);
+
 internal interface IOutputFormatter
 {
-    void Format(IReadOnlyList<AnalyzedProject> projects,TextWriter writer);
+    void Format(IReadOnlyList<AnalyzedProject> projects, IDictionary<string,string> options);
 }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -38,6 +38,14 @@ namespace DotNetOutdated
         private readonly IProjectDiscoveryService _projectDiscoveryService;
         private readonly IDotNetAddPackageService _dotNetAddPackageService;
         private readonly ICentralPackageVersionManagementService _centralPackageVersionManagementService;
+        private readonly OutputFormatterFactory _outputFormatterFactory;
+        private static readonly Dictionary<string, Type> _formatters =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                {nameof(OutputFormat.Json), typeof(Formatters.JsonFormatter)},
+                {nameof(OutputFormat.Csv), typeof(Formatters.CsvFormatter)},
+                {nameof(OutputFormat.Markdown), typeof(Formatters.MarkdownFormatter)},
+            };
 
         [Option(CommandOptionType.NoValue, Description = "Specifies whether to include auto-referenced packages.",
             LongName = "include-auto-references")]
@@ -88,10 +96,10 @@ namespace DotNetOutdated
             ShortName = "o", LongName = "output")]
         public string OutputFilename { get; set; } = null;
 
-        [Option(CommandOptionType.SingleValue, Description = "Specifies the output format for the generated report. " +
+        [Option(CommandOptionType.MultipleValue, Description = "Specifies the output format for the generated report. " +
                                                              "Possible values: json (default) or csv.",
             ShortName = "of", LongName = "output-format")]
-        public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
+        public List<string> OutputFileFormat { get; set; } = new() { nameof(OutputFormat.Json) };
 
         [Option(CommandOptionType.SingleValue, Description = "Only include package versions that are older than the specified number of days.",
             ShortName = "ot", LongName = "older-than")]
@@ -127,6 +135,19 @@ namespace DotNetOutdated
                     .AddSingleton<INuGetPackageInfoService, NuGetPackageInfoService>()
                     .AddSingleton<INuGetPackageResolutionService, NuGetPackageResolutionService>()
                     .AddSingleton<ICentralPackageVersionManagementService, CentralPackageVersionManagementService>()
+                    .AddSingleton<Formatters.JsonFormatter>()
+                    .AddSingleton<Formatters.CsvFormatter>()
+                    .AddSingleton<Formatters.MarkdownFormatter>()
+                    .AddSingleton<OutputFormatterFactory>(provider => (string name, out IOutputFormatter formatter) =>
+                        {
+                            formatter = default;
+                            if (_formatters.TryGetValue(name, out var formatterType))
+                            {
+                                formatter = provider.GetService(formatterType) as IOutputFormatter;
+                                return formatter is not null;
+                            }
+                            return false;
+                        })
                     .BuildServiceProvider();
 
             using var app = new CommandLineApplication<Program>();
@@ -142,8 +163,15 @@ namespace DotNetOutdated
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             .InformationalVersion;
 
-        public Program(IFileSystem fileSystem, IReporter reporter, INuGetPackageResolutionService nugetService, IProjectAnalysisService projectAnalysisService,
-            IProjectDiscoveryService projectDiscoveryService, IDotNetAddPackageService dotNetAddPackageService, ICentralPackageVersionManagementService centralPackageVersionManagementService)
+        public Program(IFileSystem fileSystem
+            , IReporter reporter
+            , INuGetPackageResolutionService nugetService
+            , IProjectAnalysisService projectAnalysisService
+            , IProjectDiscoveryService projectDiscoveryService
+            , IDotNetAddPackageService dotNetAddPackageService
+            , ICentralPackageVersionManagementService centralPackageVersionManagementService
+            , OutputFormatterFactory outputFormatterFactory
+            )
         {
             _fileSystem = fileSystem;
             _reporter = reporter;
@@ -152,6 +180,7 @@ namespace DotNetOutdated
             _projectDiscoveryService = projectDiscoveryService;
             _dotNetAddPackageService = dotNetAddPackageService;
             _centralPackageVersionManagementService = centralPackageVersionManagementService;
+            _outputFormatterFactory = outputFormatterFactory;
         }
 
         public async Task<int> OnExecute(CommandLineApplication app, IConsole console)
@@ -525,21 +554,63 @@ namespace DotNetOutdated
 
         private void GenerateOutputFile(List<AnalyzedProject> projects)
         {
-            if (OutputFilename != null)
+            // Get list of formatters
+            var outputFileFormats = OutputFileFormat;
+            foreach (var outputFileFormat in outputFileFormats)
             {
-                Console.WriteLine();
-                Console.WriteLine($"Generating {OutputFileFormat.ToString().ToUpperInvariant()} report...");
-                using var stream = _fileSystem.File.Create(OutputFilename);
-                using var sw = new StreamWriter(stream);
-                IOutputFormatter formatter = OutputFileFormat switch
+                var context = GetFormatterTypeAndOptions(outputFileFormat);
+                Format(projects, context);
+            }
+
+            void Format(List<AnalyzedProject> projects, (string formatterType, IDictionary<string, string> options) context)
+            {
+                if (!context.options.TryGetValue("outputFile", out var outputFile))
                 {
-                    OutputFormat.Csv => new Formatters.CsvFormatter(),
-                    OutputFormat.Markdown => new Formatters.MarkdownFormatter(),
-                    _ => new Formatters.JsonFormatter(),
-                };
-                formatter.Format(projects, sw);
-                Console.WriteLine($"Report written to {OutputFilename}");
-                Console.WriteLine();
+                    outputFile = OutputFilename;
+                    context.options["outputFile"] = outputFile;
+                }
+                if (_outputFormatterFactory(context.formatterType, out var formatter))
+                {
+                    formatter.Format(projects, context.options);
+                }
+                else
+                {
+                    Console.Error.Write($"The formatter {context.formatterType} is invalid.", Constants.ReportingColors.Error);
+                    Console.WriteLine();
+                }
+            }
+
+            // this function parse OutputFileFormat arg and extract formatterType and its oprions.
+            // the format is <formatterType[;[<option>[=<optionValue>,];...>
+            // eg: csv;separator=\t;outputfile=./pippo.csv
+            (string formatterType, IDictionary<string, string> options) GetFormatterTypeAndOptions(string arguments)
+            {
+                Dictionary<string, string> options = new(StringComparer.OrdinalIgnoreCase);
+                string formatterType = default;
+                if (!string.IsNullOrEmpty(arguments))
+                {
+                    if (arguments.Split(';') is { Length: >= 1 } segments)
+                    {
+                        formatterType = segments[0];
+                        for (int i = 1; i < segments.Length; i++)
+                        {
+                            var segment = segments[i];
+                            if (!string.IsNullOrEmpty(segment))
+                            {
+                                var index = segment.IndexOf('=');
+                                if (index > -1)
+                                {
+                                    options[segment.Substring(0, index - 1)] = segment.Substring(index + 1);
+                                }
+                                else
+                                {
+                                    options[segment] = segment;
+                                }
+                            }
+                        }
+                    }
+                }
+                return (formatterType, options);
             }
         }
 

--- a/src/DotNetOutdated/ReportingColors.cs
+++ b/src/DotNetOutdated/ReportingColors.cs
@@ -14,5 +14,7 @@ namespace DotNetOutdated
 
         public ConsoleColor UpgradeSuccess { get; } = ConsoleColor.Green;
         public ConsoleColor UpgradeFailure { get; } = ConsoleColor.Red;
+
+        public ConsoleColor Error { get; } = ConsoleColor.Red;
     }
 }


### PR DESCRIPTION
Allow to generate more than one output at once eg:

```bash
dotnet-outdated -o outdated -of Markdown -of Csv -of Json;Indentation=none
```

Each formatter can have its own options separated by `;`. At moment formatters only implement the `outputFile` option.


Fixes #447