### PR TITLE
Fix xUnit1030 warning

### DIFF
--- a/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
+++ b/test/DotNetOutdated.Tests/NuGetPackageResolutionServiceTests.cs
@@ -61,7 +61,7 @@ namespace DotNetOutdated.Tests
             // Arrange
 
             // Act
-            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0).ConfigureAwait(false);
+            var latestVersion = await _nuGetPackageResolutionService.ResolvePackageVersions(_packageName, NuGetVersion.Parse(current), new List<Uri>(), VersionRange.Parse(current), versionLock, prerelease, null, null, false, 0);
 
             // Assert
             Assert.Equal(NuGetVersion.Parse(latest), latestVersion);


### PR DESCRIPTION
Fix xUnit1030 warning by removing call to `ConfigureAwait(false)`.
