### PR TITLE
Ignoring  downgrade warning NU1605 during preparation (graph build)

### DIFF
--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -26,7 +26,7 @@ namespace DotNetOutdated.Core.Services
         {
             var dgOutput = _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), _fileSystem.Path.GetTempFileName());
 
-            string[] arguments = { "msbuild", $"\"{projectPath}\"", "/t:Restore,GenerateRestoreGraphFile", $"/p:RestoreGraphOutputPath=\"{dgOutput}\"" };
+            string[] arguments = { "msbuild", $"\"{projectPath}\"", "/p:NoWarn=NU1605", "/t:Restore,GenerateRestoreGraphFile", $"/p:RestoreGraphOutputPath=\"{dgOutput}\"" };
 
             var runStatus = _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments);
 


### PR DESCRIPTION
Previous behavior: The update of outdated packages might break because of downgrade warnings.
An upgrade might actually fix downgrade warnings so the warning NU1605 is now ignored during graph build which makes the tool more reliable.