### PR TITLE
POC Expose `-bc` / `--ms-build-configuration` command option

### DIFF
--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -22,11 +22,11 @@ namespace DotNetOutdated.Core.Services
             _fileSystem = fileSystem;
         }
 
-        public DependencyGraphSpec GenerateDependencyGraph(string projectPath)
+        public DependencyGraphSpec GenerateDependencyGraph(string projectPath, string msBuildConfiguration)
         {
             var dgOutput = _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), _fileSystem.Path.GetTempFileName());
 
-            string[] arguments = { "msbuild", $"\"{projectPath}\"", "/t:Restore,GenerateRestoreGraphFile", $"/p:RestoreGraphOutputPath=\"{dgOutput}\"" };
+            string[] arguments = { "msbuild", $"\"{projectPath}\"", "/t:Restore,GenerateRestoreGraphFile", $"/p:RestoreGraphOutputPath=\"{dgOutput}\"", $"/p:Configuration=\"{msBuildConfiguration}\"" };
 
             var runStatus = _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments);
 

--- a/src/DotNetOutdated.Core/Services/IDependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/IDependencyGraphService.cs
@@ -4,6 +4,6 @@ namespace DotNetOutdated.Core.Services
 {
     public interface IDependencyGraphService
     {
-        DependencyGraphSpec GenerateDependencyGraph(string projectPath);
+        DependencyGraphSpec GenerateDependencyGraph(string projectPath, string msBuildConfiguration);
     }
 }

--- a/src/DotNetOutdated.Core/Services/IProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/IProjectAnalysisService.cs
@@ -5,6 +5,6 @@ namespace DotNetOutdated.Core.Services
 {
     public interface IProjectAnalysisService
     {
-        List<Project> AnalyzeProject(string projectPath, bool runRestore, bool includeTransitiveDependencies, int transitiveDepth);
+        List<Project> AnalyzeProject(string projectPath, bool runRestore, bool includeTransitiveDependencies, int transitiveDepth, string msBuildConfiguration);
     }
 }

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -23,9 +23,9 @@ namespace DotNetOutdated.Core.Services
             _fileSystem = fileSystem;
         }
 
-        public List<Project> AnalyzeProject(string projectPath, bool runRestore, bool includeTransitiveDependencies, int transitiveDepth)
+        public List<Project> AnalyzeProject(string projectPath, bool runRestore, bool includeTransitiveDependencies, int transitiveDepth, string msBuildConfiguration)
         {
-            var dependencyGraph = _dependencyGraphService.GenerateDependencyGraph(projectPath);
+            var dependencyGraph = _dependencyGraphService.GenerateDependencyGraph(projectPath, msBuildConfiguration);
             if (dependencyGraph == null)
                 return null;
 

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -112,6 +112,10 @@ namespace DotNetOutdated
             ShortName = "utd", LongName = "include-up-to-date")]
         public bool IncludeUpToDate { get; set; } = false;
 
+        [Option(CommandOptionType.SingleValue, Description = "MSBuild configuration. Generally Debug or Release, but configurable at the solution and project levels.",
+            ShortName = "bc", LongName = "ms-build-configuration")]
+        public string MsBuildConfiguration { get; set; } = "Debug";
+
         public static int Main(string[] args)
         {
             using var services = new ServiceCollection()
@@ -182,7 +186,7 @@ namespace DotNetOutdated
                 // Analyze the projects
                 console.Write("Analyzing project(s)...");
 
-                var projects = projectPaths.SelectMany(path => _projectAnalysisService.AnalyzeProject(path, false, Transitive, TransitiveDepth)).ToList();
+                var projects = projectPaths.SelectMany(path => _projectAnalysisService.AnalyzeProject(path, false, Transitive, TransitiveDepth, MsBuildConfiguration)).ToList();
 
                 if (!console.IsOutputRedirected)
                     ClearCurrentConsoleLine();

--- a/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
@@ -29,7 +29,7 @@ namespace DotNetOutdated.Tests
                 {
                     var directory = x.ArgAt<string>(0);
                     var arguments = x.ArgAt<string[]>(1);
-                    
+
                     ArgumentNullException.ThrowIfNull(directory);
 
                     // Grab the temp filename that was passed...
@@ -42,7 +42,7 @@ namespace DotNetOutdated.Tests
             var graphService = new DependencyGraphService(dotNetRunner, mockFileSystem);
 
             // Act
-            var dependencyGraph = graphService.GenerateDependencyGraph(_path);
+            var dependencyGraph = graphService.GenerateDependencyGraph(_path, "Debug");
 
             // Assert
             Assert.NotNull(dependencyGraph);
@@ -64,7 +64,7 @@ namespace DotNetOutdated.Tests
             var graphService = new DependencyGraphService(dotNetRunner, mockFileSystem);
 
             // Assert
-            Assert.Throws<CommandValidationException>(() => graphService.GenerateDependencyGraph(_path));
+            Assert.Throws<CommandValidationException>(() => graphService.GenerateDependencyGraph(_path, "Debug"));
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace DotNetOutdated.Tests
             var graphService = new DependencyGraphService(dotNetRunner, mockFileSystem);
 
             // Act
-            var dependencyGraph = graphService.GenerateDependencyGraph(_solutionPath);
+            var dependencyGraph = graphService.GenerateDependencyGraph(_solutionPath, "Debug");
 
             // Assert
             Assert.NotNull(dependencyGraph);


### PR DESCRIPTION
Allow to provide `Configuration` value to `MSBuild`.

This will allow to handle configuration like (`YYY.csproj`):

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <Choose>
    <When Condition="'$(Configuration)'=='Debug'">
      <ItemGroup>
        <ProjectReference Include="../../../XXX/src/XXX/XXX.csproj">
          <Name>XXX</Name>
          <TargetFramework>net8.0</TargetFramework>
        </ProjectReference>
      </ItemGroup>
    </When>
    <Otherwise>
      <ItemGroup>
        <PackageReference Include="XXX" Version="1.2.3" />
      </ItemGroup>
    </Otherwise>
  </Choose>
</Project>
```

and `dotnet outdated -bc Release`.

Related: https://github.com/dotnet-outdated/dotnet-outdated/issues/406