### PR TITLE
Support updating GlobalPackageReference

### DIFF
--- a/src/DotNetOutdated.Core/Services/CentralPackageVersionManagementService.cs
+++ b/src/DotNetOutdated.Core/Services/CentralPackageVersionManagementService.cs
@@ -44,7 +44,7 @@ namespace DotNetOutdated.Core.Services
 
                         if (fileContent.IndexOf($"\"{packageName}\"", StringComparison.OrdinalIgnoreCase) != -1)
                         {
-                            string newFileContent = Regex.Replace(fileContent, $"(<PackageVersion\\s*(?:Include|Update)=\"{packageName}\"\\s*Version=\")([^\"]*)(\".*\\/>)", m => $"{m.Groups[1].Captures[0].Value}{version}{m.Groups[3].Captures[0].Value}");
+                            string newFileContent = Regex.Replace(fileContent, $"(<(?:PackageVersion|GlobalPackageReference)\\s*(?:Include|Update)=\"{packageName}\"\\s*Version=\")([^\"]*)(\".*\\/>)", m => $"{m.Groups[1].Captures[0].Value}{version}{m.Groups[3].Captures[0].Value}");
 
                             if (newFileContent != fileContent)
                             {

--- a/test/DotNetOutdated.Tests/CentralPackageVersionManagementTests.cs
+++ b/test/DotNetOutdated.Tests/CentralPackageVersionManagementTests.cs
@@ -8,13 +8,15 @@ namespace DotNetOutdated.Tests
 {
     public class CentralPackageVersionManagementTests
     {
-        [Fact]
-        public void UpgradingCPVMEnabledPackageUpdatesNearestCPVMFile()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void UpgradingCPVMEnabledPackageUpdatesNearestCPVMFile(bool isGlobalPackage)
         {
             SetupCPVMMocks(out IDotNetRestoreService mockRestoreService, out MockFileSystem mockFileSystem, out string path, out string nearestCPVMFilePath, out string rootCPVMFilePath, out string rootCPVMFileContent, out string _, out string _);
 
             var subject = new CentralPackageVersionManagementService(mockFileSystem, mockRestoreService);
-            RunStatus status = subject.AddPackage(path, "FakePackage", new NuGet.Versioning.NuGetVersion(2, 0, 0), false);
+            RunStatus status = subject.AddPackage(path, isGlobalPackage ? "GlobalFakePackage" : "FakePackage", new NuGet.Versioning.NuGetVersion(2, 0, 0), false);
 
             Assert.NotNull(status);
             Assert.Equal(0, status.ExitCode);

--- a/test/DotNetOutdated.Tests/TestData/CPVMFile.props
+++ b/test/DotNetOutdated.Tests/TestData/CPVMFile.props
@@ -1,5 +1,8 @@
 <Project>
 	<ItemGroup>
+		<GlobalPackageReference Include="GlobalFakePackage" Version="1.0.0" />
+	</ItemGroup>
+	<ItemGroup>
 		<PackageVersion Include="FakePackage" Version="1.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
resolve https://github.com/dotnet-outdated/dotnet-outdated/issues/518, make `dotnet-outdated` support updating nuget versions in `<GlobalPackageReferences>` in `Directory.Packages.props`.
