### PR TITLE
Allow dev-deps to be filtered by target framework version

### DIFF
--- a/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
@@ -9,9 +9,9 @@ namespace DotNetOutdated.Core.Services
     public interface INuGetPackageInfoService
     {
         Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath,
-            bool isDevelopmentDependency);
+            bool shouldReduceByTargetFrameworkVersion);
 
         Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath,
-            bool isDevelopmentDependency, int olderThanDays, bool ignoreFailedSources);
+            bool shouldReduceByTargetFrameworkVersion, int olderThanDays, bool ignoreFailedSources);
     }
 }

--- a/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageResolutionService.cs
@@ -10,10 +10,10 @@ namespace DotNetOutdated.Core.Services
     {
         Task<NuGetVersion> ResolvePackageVersions(string packageName,
             NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
-            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency);
+            NuGetFramework targetFrameworkName, string projectFilePath, bool shouldReduceByTargetFrameworkVersion);
 
         Task<NuGetVersion> ResolvePackageVersions(string packageName,
             NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange, VersionLock versionLock, PrereleaseReporting prerelease,
-            NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays, bool ignoreFailedSources);
+            NuGetFramework targetFrameworkName, string projectFilePath, bool shouldReduceByTargetFrameworkVersion, int olderThanDays, bool ignoreFailedSources);
     }
 }

--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -67,13 +67,13 @@ namespace DotNetOutdated.Core.Services
         }
 
         public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
-            string projectFilePath, bool isDevelopmentDependency)
+            string projectFilePath, bool shouldReduceByTargetFrameworkVersion)
         {
-            return await GetAllVersions(package, sources, includePrerelease, targetFramework, projectFilePath, isDevelopmentDependency, 0).ConfigureAwait(false);
+            return await GetAllVersions(package, sources, includePrerelease, targetFramework, projectFilePath, shouldReduceByTargetFrameworkVersion, 0).ConfigureAwait(false);
         }
 
         public async Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework,
-            string projectFilePath, bool isDevelopmentDependency, int olderThanDays, bool ignoreFailedSources = false)
+            string projectFilePath, bool shouldReduceByTargetFrameworkVersion, int olderThanDays, bool ignoreFailedSources = false)
         {
             if (sources == null)
                 throw new ArgumentNullException(nameof(sources));
@@ -94,9 +94,7 @@ namespace DotNetOutdated.Core.Services
                                                                                        c.Published <= DateTimeOffset.UtcNow.AddDays(-olderThanDays)).ToList();
                         }
 
-                        // We need to ensure that we only get package versions which are compatible with the requested target framework.
-                        // For development dependencies, we do not perform this check
-                        if (!isDevelopmentDependency)
+                        if (shouldReduceByTargetFrameworkVersion)
                         {
                             var reducer = new FrameworkReducer();
 

--- a/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageResolutionService.cs
@@ -20,14 +20,14 @@ namespace DotNetOutdated.Core.Services
         }
 
         public async Task<NuGetVersion> ResolvePackageVersions(string packageName, NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange,
-            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency)
+            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool shouldReduceByTargetFrameworkVersion)
         {
             return await ResolvePackageVersions(packageName, referencedVersion, sources, currentVersionRange, versionLock, prerelease, targetFrameworkName, projectFilePath,
-                isDevelopmentDependency, 0).ConfigureAwait(false);
+                shouldReduceByTargetFrameworkVersion, 0).ConfigureAwait(false);
         }
 
         public async Task<NuGetVersion> ResolvePackageVersions(string packageName, NuGetVersion referencedVersion, IEnumerable<Uri> sources, VersionRange currentVersionRange,
-            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool isDevelopmentDependency, int olderThanDays, bool ignoreFailedSources = false)
+            VersionLock versionLock, PrereleaseReporting prerelease, NuGetFramework targetFrameworkName, string projectFilePath, bool shouldReduceByTargetFrameworkVersion, int olderThanDays, bool ignoreFailedSources = false)
         {
             if (referencedVersion == null)
                 throw new ArgumentNullException(nameof(referencedVersion));
@@ -42,7 +42,7 @@ namespace DotNetOutdated.Core.Services
             string cacheKey = (packageName + "-" + includePrerelease + "-" + targetFrameworkName + "-" + olderThanDays).ToUpperInvariant();
 
             // Get all the available versions
-            var allVersionsRequest = new Lazy<Task<IReadOnlyList<NuGetVersion>>>(() => this._nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath, isDevelopmentDependency, olderThanDays, ignoreFailedSources));
+            var allVersionsRequest = new Lazy<Task<IReadOnlyList<NuGetVersion>>>(() => this._nugetService.GetAllVersions(packageName, sources, includePrerelease, targetFrameworkName, projectFilePath, shouldReduceByTargetFrameworkVersion, olderThanDays, ignoreFailedSources));
             var allVersions = await _cache.GetOrAdd(cacheKey, allVersionsRequest).Value.ConfigureAwait(false);
 
             // Determine the floating behaviour

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -112,6 +112,10 @@ namespace DotNetOutdated
             ShortName = "utd", LongName = "include-up-to-date")]
         public bool IncludeUpToDate { get; set; } = false;
 
+        [Option(CommandOptionType.NoValue, Description = "Default behavior is to not filter version by target framework version for development dependencies.  Specify this option if you would like to override this and filter development dependencies by target framework version.",
+            ShortName = "fddbtfv", LongName = "filter-dev-deps-by-target-framework-version")]
+        public bool? FilterDevelopmentDependenciesByTargetFramework { get; set; }
+
         public static int Main(string[] args)
         {
             using var services = new ServiceCollection()
@@ -488,8 +492,10 @@ namespace DotNetOutdated
 
             if (referencedVersion != null)
             {
+                var filterDevelopmentDependenciesByTargetFramework = FilterDevelopmentDependenciesByTargetFramework.GetValueOrDefault(!dependency.IsDevelopmentDependency);
+                
                 latestVersion = await _nugetService.ResolvePackageVersions(dependency.Name, referencedVersion, project.Sources, dependency.VersionRange,
-                    VersionLock, Prerelease, targetFramework.Name, project.FilePath, dependency.IsDevelopmentDependency, OlderThanDays, IgnoreFailedSources).ConfigureAwait(false);
+                    VersionLock, Prerelease, targetFramework.Name, project.FilePath, filterDevelopmentDependenciesByTargetFramework, OlderThanDays, IgnoreFailedSources).ConfigureAwait(false);
             }
 
             if (referencedVersion == null || latestVersion == null || referencedVersion != latestVersion || IncludeUpToDate)


### PR DESCRIPTION
This tool is perfect for my team's needs - with one exception:  It doesn't filter development dependencies by target framework version like it does other kinds of dependencies.  I think I see the reasoning behind not filtering, but in our case we have EF Core libraries which are marked as dev-dep=true which are referenced by our application code (e.g. Microsoft.EntityFrameworkCore.Design).  That results in this tool always suggesting a higher version then what can be compiled.  I would prefer to be able to have these filtered as well.

To accomplish this I introduced a new CLI option named  `--filter-dev-deps-by-target-framework-version`.  I'm all ears to a shorter/easier option name if you have any ideas.