### PR TITLE
Added support for updating dependencies file

### DIFF
--- a/src/DotNetOutdated.Core/Services/DependencyFileAddPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyFileAddPackageService.cs
@@ -1,0 +1,207 @@
+﻿using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace DotNetOutdated.Core.Services
+{
+    public class DependencyFileAddPackageService : IDotNetAddPackageService
+    {
+        private readonly Regex _versionVariable = new Regex(@"^\$\((?<version>\S+)\)$");
+
+        private readonly IFileSystem _fileSystem;
+        private readonly Lazy<IReadOnlyDictionary<string, Updater>> _updaterPerName;
+        private readonly Lazy<XDocument> _document;
+
+
+        public DependencyFileAddPackageService(IFileSystem fileSystem, string dependencyFile)
+        {
+            _fileSystem = fileSystem;
+            DependencyFile = dependencyFile;
+            _document = new Lazy<XDocument>(InitDocument);
+            _updaterPerName = new Lazy<IReadOnlyDictionary<string, Updater>>(Init);
+        }
+
+        private XDocument InitDocument()
+        {
+            var fi = _fileSystem.FileInfo.New(DependencyFile);
+            using var stream = fi.OpenRead();
+            return XDocument.Load(stream);
+        }
+
+        private IReadOnlyDictionary<string, Updater> Init()
+        {
+            XDocument document = _document.Value;
+            var properties = new Dictionary<string, XElement>(StringComparer.Ordinal);
+            var references = new Dictionary<string, Updater>(StringComparer.Ordinal);
+            foreach (var item in document.Root.Elements())
+            {
+                if ("PropertyGroup".Equals(item.Name.LocalName))
+                {
+                    AddProperties(item);
+                }
+                else if ("ItemGroup".Equals(item.Name.LocalName))
+                {
+                    AddReferences(item);
+                }
+            }
+
+            return references;
+
+            void AddProperties(XElement propertyGroup)
+            {
+                foreach (var item in propertyGroup.Elements())
+                {
+                    properties[item.Name.LocalName] = item;
+                }
+            }
+
+            void AddReferences(XElement itemGroup)
+            {
+                foreach (var item in itemGroup.Elements())
+                {
+                    if ("PackageReference".Equals(item.Name.LocalName))
+                    {
+                        var name = TryGetAttributeValue(item, "Update", out var value)
+                            ? value
+                            : TryGetAttributeValue(item, "Include", out value)
+                                ? value
+                                : throw new FormatException($"Unknown package reference: {item}");
+                        var version = TryGetAttributeValue(item, "Version", out var v)
+                            ? v
+                            : throw new FormatException($"Can't find version: {item}");
+
+                        if (TryGetVariableName(version, out var variable))
+                        {
+                            references[name] = new VariableUpdater(name, variable, properties);
+                        }
+                        else
+                        {
+                            references[name] = new XElementUpdater(name, item);
+                        }
+                    }
+                }
+            }
+
+            string GetAttributeValue(XElement element, string name)
+            {
+                var match = GetAttribute(element, name);
+                return match != null
+                    ? match.Value
+                    : string.Empty;
+            }
+
+            bool TryGetAttributeValue(XElement element, string name, out string value)
+            {
+                value = GetAttributeValue(element, name);
+                return !string.IsNullOrWhiteSpace(value);
+            }
+
+            bool TryGetVariableName(string version, out string variableName)
+            {
+                var match = _versionVariable.Match(version);
+                if (match.Success)
+                {
+                    variableName = match.Groups["version"].Value;
+                    return true;
+                }
+
+                variableName = null;
+                return false;
+            }
+        }
+
+        public string DependencyFile { get; }
+
+        public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version)
+        {
+            return AddPackage(projectPath, packageName, frameworkName, version, false);
+        }
+
+        public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version, bool noRestore, bool ignoreFailedSources = false)
+        {
+            var update = _updaterPerName.Value.TryGetValue(packageName, out var updater)
+                ? updater.Update(version)
+                : new RunStatus($"Failed: {packageName}", "Not found", -1);
+            if (update.IsSuccess)
+            {
+                // Save the document
+                var fi = _fileSystem.FileInfo.New(DependencyFile);
+                using var stream = fi.Create();
+                _document.Value.Save(stream);
+            }
+
+            return update;
+        }
+
+        private XAttribute GetAttribute(XElement element, string name)
+        {
+            return element.Attributes().LastOrDefault(a => name.Equals(a.Name.LocalName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private abstract class Updater
+        {
+            protected Updater(string packageName)
+            {
+                PackageName = packageName;
+            }
+
+            public string PackageName { get; }
+
+            internal abstract RunStatus Update(NuGetVersion version);
+        }
+
+        private sealed class VariableUpdater : Updater
+        {
+            private string _name;
+            private Dictionary<string, XElement> _properties;
+
+            public VariableUpdater(string packageName, string name, Dictionary<string, XElement> properties) : base(packageName)
+            {
+                _name = name;
+                _properties = properties;
+            }
+
+            internal override RunStatus Update(NuGetVersion version)
+            {
+                var versionStr = version.ToNormalizedString();
+                if (_properties.TryGetValue(_name, out var element))
+                {
+                    // Check if contains another variable, if so skip it
+                    var currentValue = element.Value;
+                    if (!string.IsNullOrWhiteSpace(currentValue) && element.Value.Contains("$("))
+                    {
+                        // NOOP: Points to another variable
+                        return new RunStatus($"{PackageName} Variable {_name} = {versionStr}, (NOOP)", string.Empty, 0);
+                    }
+
+                    element.SetValue(versionStr);
+                    return new RunStatus($"{PackageName} Variable {_name} = {versionStr}", string.Empty, 0);
+                }
+
+                return new RunStatus($"{PackageName} Variable {_name} = {versionStr}", "Not found", -1);
+            }
+        }
+
+        private sealed class XElementUpdater : Updater
+        {
+            private readonly XElement _item;
+
+            public XElementUpdater(string packageName, XElement item) : base(packageName)
+            {
+                _item = item;
+            }
+
+            internal override RunStatus Update(NuGetVersion version)
+            {
+                var versionStr = version.ToNormalizedString();
+                var attributeKey = _item.Name.Namespace.GetName("Version");
+                 _item.SetAttributeValue(attributeKey, versionStr);
+                return new RunStatus($"{PackageName} = {versionStr}", string.Empty, 0);
+            }
+        }
+    }
+}

--- a/src/DotNetOutdated/Services/ConfiguredAddPackageService.cs
+++ b/src/DotNetOutdated/Services/ConfiguredAddPackageService.cs
@@ -1,0 +1,43 @@
+﻿using DotNetOutdated.Core.Services;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.DependencyInjection;
+using NuGet.Versioning;
+using System;
+using System.IO.Abstractions;
+
+namespace DotNetOutdated.Services
+{
+    /// <summary>
+    /// A wrapper for the service to use. Since the program needs to be fully constructed before we
+    /// can have access to the options.
+    /// </summary>
+    public class ConfiguredAddPackageService : IDotNetAddPackageService
+    {
+        private readonly Lazy<IDotNetAddPackageService> _configuredService;
+        private readonly IServiceProvider _services;
+
+        public ConfiguredAddPackageService(IServiceProvider serviceProvider)
+        {
+            _services = serviceProvider;
+            _configuredService = new Lazy<IDotNetAddPackageService>(Init);
+        }
+
+        public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version)
+        {
+            return _configuredService.Value.AddPackage(projectPath, packageName, frameworkName, version);
+        }
+
+        public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version, bool noRestore, bool ignoreFailedSources)
+        {
+            return _configuredService.Value.AddPackage(projectPath, packageName, frameworkName, version, noRestore, ignoreFailedSources);
+        }
+
+        private IDotNetAddPackageService Init()
+        {
+            var app = _services.GetRequiredService<CommandLineApplication<Program>>();
+            return !string.IsNullOrWhiteSpace(app.Model.DependencyFile)
+                    ? new DependencyFileAddPackageService(_services.GetRequiredService<IFileSystem>(), app.Model.DependencyFile)
+                    : _services.GetRequiredService<DotNetAddPackageService>();
+        }
+    }
+}

--- a/test/DotNetOutdated.Tests/ConfiguredAddPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/ConfiguredAddPackageServiceTests.cs
@@ -1,0 +1,117 @@
+﻿using Xunit;
+using System;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.DependencyInjection;
+using DotNetOutdated.Core.Services;
+using DotNetOutdated.Services;
+using System.Reflection;
+using System.Linq;
+using NSubstitute;
+using System.Collections.Generic;
+using DotNetOutdated.Core.Models;
+using NuGet.Versioning;
+using NuGet.Frameworks;
+
+namespace DotNetOutdated.Tests
+{
+    public class ConfiguredAddPackageServiceTests
+    {
+        private readonly Context _context = new();
+
+        [Fact]
+        public void ShouldCreateConfiguredService()
+        {
+            Assert.IsType<ConfiguredAddPackageService>(_context.PackageService);
+        }
+
+        [Fact]
+        public void ShouldUseDefaultService()
+        {
+            _context.StartApp();
+            Assert.IsType<DotNetAddPackageService>(_context.PackageServiceImplementation);
+        }
+
+        [Fact]
+        public void ShouldUseDependenciesService()
+        {
+            _context.StartApp("/some.csproj", "-dpf", "some.props");
+            Assert.IsType<DependencyFileAddPackageService>(_context.PackageServiceImplementation);
+        }
+
+        private sealed class Context : IDisposable
+        {
+            private readonly CommandLineApplication<Program> _app;
+            private readonly Lazy<IServiceProvider> _services;
+            private readonly IServiceCollection _serviceCollection;
+
+            public Context()
+            {
+                _app = new();
+                _serviceCollection = SetupServices();
+                _services = new Lazy<IServiceProvider>(_serviceCollection.BuildServiceProvider);
+            }
+
+            private IServiceCollection SetupServices()
+            {
+                var services = Program.CreateServiceCollection(_app);
+                var discoveryService = Substitute.For<IProjectDiscoveryService>();
+                var projectAnalysisService = Substitute.For<IProjectAnalysisService>();
+                var restoreService = Substitute.For<IDotNetRestoreService>();
+                var project = new Project("Something", "/some/path.csproj", Enumerable.Empty<Uri>(), new NuGetVersion("1.0"));
+                var targetFramework = new TargetFramework(new NuGetFramework("dummy"));
+                var dependency = new Dependency("fake", new VersionRange(new NuGetVersion("1.0")), new NuGetVersion("1.0"), false, false, false, false);
+                targetFramework.Dependencies.Add(dependency);
+                project.TargetFrameworks.Add(targetFramework);
+                restoreService.Restore(Arg.Any<string>()).Returns(new RunStatus(string.Empty, string.Empty, 0));
+                projectAnalysisService.AnalyzeProject(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<int>()).Returns(new List<Project>() { project });
+                discoveryService.DiscoverProjects(Arg.Any<string>(), Arg.Any<bool>()).Returns(
+                   new List<string>
+                   {
+                        "/a/file.csproj"
+                   });
+                return services
+                   .AddSingleton<IConsole>(new MockConsole())
+                   .AddSingleton(discoveryService)
+                   .AddSingleton(projectAnalysisService)
+                   .AddSingleton(restoreService);
+            }
+
+            public IServiceProvider Services => _services.Value;
+
+            public IDotNetAddPackageService PackageServiceImplementation
+            {
+                get
+                {
+                    var service = PackageService is ConfiguredAddPackageService s
+                        ? s
+                        : throw new InvalidOperationException("Unexpected service type");
+                    var field = service.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance).Single(f => f.Name.Equals("_configuredService", StringComparison.Ordinal));
+                    var value = field.GetValue(service) is Lazy<IDotNetAddPackageService> l
+                        ? l
+                        : throw new InvalidOperationException("Unexpected field type");
+                    return value.Value;
+                }
+            }
+            public IDotNetAddPackageService PackageService => Services.GetRequiredService<IDotNetAddPackageService>();
+
+            public void StartApp(params string[] args)
+            {
+                _app.Conventions
+                    .UseDefaultConventions()
+                    .UseConstructorInjection(Services);
+                _app.Execute(args);
+            }
+
+            public void Dispose()
+            {
+                _app.Dispose();
+            }
+
+            public Context WithModification(Action<IServiceCollection> action)
+            {
+                action(_serviceCollection);
+                return this;
+            }
+        }
+    }
+}

--- a/test/DotNetOutdated.Tests/DependenciesFileTests.cs
+++ b/test/DotNetOutdated.Tests/DependenciesFileTests.cs
@@ -1,0 +1,155 @@
+﻿using DotNetOutdated.Core.Services;
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using NSubstitute;
+using Xunit;
+using NuGet.Versioning;
+using System;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using System.Reflection.PortableExecutable;
+
+namespace DotNetOutdated.Tests
+{
+    public class DependenciesFileTests
+    {
+        private const string _packageName = "Mediatr";
+        private readonly Context _context = new();
+
+        [Fact]
+        public void ShouldNotUpgradeProjectFile()
+        {
+            var subject = new DependencyFileAddPackageService(_context.FileSystem, _context.DependenciesFilePath);
+            RunStatus status = subject.AddPackage(_context.ProjectPath, _packageName, null, new NuGetVersion(12, 4, 0), false);
+
+            Assert.NotNull(status);
+            Assert.Equal(0, status.ExitCode);
+            Assert.Equal(_context.ProjectFileContent, _context.GetProjectFileContent());
+        }
+
+        [Fact]
+        public void ShouldUpgradeDependenciesFile()
+        {
+            var subject = new DependencyFileAddPackageService(_context.FileSystem, _context.DependenciesFilePath);
+            RunStatus status = subject.AddPackage(_context.ProjectPath, _packageName, null, new NuGetVersion(12, 4, 0), false);
+
+            Assert.NotNull(status);
+            Assert.Equal(0, status.ExitCode);
+            Assert.NotEqual(_context.DependenciesFileContent, _context.GetDependenciesContent());
+        }
+
+        [Fact]
+        public void ShouldUpgradeVersionAttribute()
+        {
+            var subject = new DependencyFileAddPackageService(_context.FileSystem, _context.DependenciesFilePath);
+            var version = new NuGetVersion(12, 4, 0);
+            var initialVersion = _context.GetPackageVersion(_packageName);
+            _ = subject.AddPackage(_context.ProjectPath, _packageName, null, version, false);
+            var updatedVersion = _context.GetPackageVersion(_packageName);
+
+            Assert.NotEqual(version, initialVersion);
+            Assert.Equal(version, updatedVersion);
+        }
+
+        [Fact]
+        public void ShouldUpgradeVariable()
+        {
+            var subject = new DependencyFileAddPackageService(_context.FileSystem, _context.DependenciesFilePath);
+            var version = new NuGetVersion(12, 4, 0);
+            var packageName = "OpenTelemetry";
+            var variableName = "OpenTelemetryVersion";
+            var initialVersion = _context.GetVariableVersion(variableName);
+            _ = subject.AddPackage(_context.ProjectPath, packageName, null, version, false);
+            var updatedVersion = _context.GetVariableVersion(variableName);
+
+            Assert.NotEqual(version, initialVersion);
+            Assert.Equal(version, updatedVersion);
+        }
+
+        [Fact]
+        public void ShouldNotUpgradeVariableContainingVariable()
+        {
+            var subject = new DependencyFileAddPackageService(_context.FileSystem, _context.DependenciesFilePath);
+            var packageName = "OpenTelemetry.Instrumentation.Http";
+            var variableName = "OpenTelemetryInstrumentationVersion";
+            var initialValue = _context.GetVariableValue(variableName);
+            var initialVersion = _context.GetPackageVersionString(packageName);
+            _ = subject.AddPackage(_context.ProjectPath, packageName, null, new NuGetVersion(12, 4, 0), false);
+            var updatedValue = _context.GetVariableValue(variableName);
+            var updatedVersion = _context.GetPackageVersionString(packageName);
+
+            Assert.Equal(initialValue, updatedValue);
+            Assert.Equal(initialVersion, updatedVersion);
+        }
+
+        private sealed class Context
+        {
+            public Context()
+            {
+                MockRestoreService = Substitute.For<IDotNetRestoreService>();
+                MockRestoreService.Restore(Arg.Any<string>()).Returns(new RunStatus(string.Empty, string.Empty, 0));
+                FileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+                ProjectPath = MockUnixSupport.Path(@"c:\source\project\app\app.csproj");
+                FileSystem.AddFileFromEmbeddedResource(ProjectPath, GetType().Assembly, "DotNetOutdated.Tests.TestData.DependenciesTest.csproj");
+                ProjectFileContent = FileSystem.GetFile(ProjectPath).TextContents;
+
+                DependenciesFilePath = MockUnixSupport.Path(@"c:\source\project\msbuild\dependencies.props");
+                FileSystem.AddFileFromEmbeddedResource(DependenciesFilePath, GetType().Assembly, "DotNetOutdated.Tests.TestData.dependencies.props");
+                DependenciesFileContent = FileSystem.GetFile(DependenciesFilePath).TextContents;
+            }
+
+            public IDotNetRestoreService MockRestoreService { get; }
+            public MockFileSystem FileSystem { get; }
+            public string ProjectPath { get; }
+            public string ProjectFileContent { get; }
+            public string DependenciesFilePath { get; }
+            public object DependenciesFileContent { get; }
+
+            public string GetDependenciesContent()
+            {
+                return FileSystem.GetFile(DependenciesFilePath).TextContents;
+            }
+
+            public string GetProjectFileContent()
+            {
+                return FileSystem.GetFile(ProjectPath).TextContents;
+            }
+
+            internal NuGetVersion GetPackageVersion(string packageName)
+            {
+                var version = GetPackageVersionString(packageName);
+                return !string.IsNullOrWhiteSpace(version)
+                    ? NuGetVersion.Parse(version)
+                    : throw new ArgumentException($"{packageName} not found", nameof(packageName));
+            }
+
+            internal string GetPackageVersionString(string packageName)
+            {
+                using var stream = FileSystem.FileInfo.New(DependenciesFilePath).OpenRead();
+                var doc = XDocument.Load(stream);
+                var match = doc.Root.XPathSelectElement($"//PackageReference[@Update='{packageName}']");
+                return match != null
+                    ? match.Attribute("Version").Value
+                    : throw new ArgumentException($"{packageName} not found", nameof(packageName));
+            }
+
+            internal NuGetVersion GetVariableVersion(string variableName)
+            {
+                var value = GetVariableValue(variableName);
+                return !string.IsNullOrWhiteSpace(value)
+                    ? NuGetVersion.Parse(value)
+                    : throw new ArgumentException($"{variableName} not found", nameof(variableName));
+            }
+
+            internal string GetVariableValue(string variableName)
+            {
+                using var stream = FileSystem.FileInfo.New(DependenciesFilePath).OpenRead();
+                var doc = XDocument.Load(stream);
+                var match = doc.Root.XPathSelectElement($"//PropertyGroup/{variableName}");
+                return match != null
+                    ? match.Value
+                    : throw new ArgumentException($"{variableName} not found", nameof(variableName));
+            }
+        }
+    }
+}

--- a/test/DotNetOutdated.Tests/TestData/DependenciesTest.csproj
+++ b/test/DotNetOutdated.Tests/TestData/DependenciesTest.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Mediatr" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+  </ItemGroup>
+
+</Project>

--- a/test/DotNetOutdated.Tests/TestData/dependencies.props
+++ b/test/DotNetOutdated.Tests/TestData/dependencies.props
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <NetCoreVersion>8.0.3</NetCoreVersion>
+    <NetAnalyzersVersion>8.0.0</NetAnalyzersVersion>
+    <RoslynatorVersion>4.11.0</RoslynatorVersion>
+    <OpenTelemetryVersion>1.7.0</OpenTelemetryVersion>
+    <OpenTelemetryInstrumentationVersion>$(OpenTelemetryVersion)</OpenTelemetryInstrumentationVersion>
+  </PropertyGroup>
+  <ItemGroup Label="Microsoft">
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(NetCoreVersion)" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Label="Others">
+    <PackageReference Update="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Update="Mediatr" Version="12.2.0" />
+    <PackageReference Update="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Update="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationVersion)" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationVersion)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Added support for updating a shared dependencies file that updates the defined package references in csproj files.
E.g. A csproj without versions defined:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp2.1</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
    <PackageReference Include="Swashbuckle.AspNetCore" />
    <PackageReference Include="Newtonsoft.Json" />
    <PackageReference Include="Mediatr" />
    <PackageReference Include="OpenTelemetry" />
    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
    <PackageReference Include="OpenTelemetry.Exporter.Console" />
    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
  </ItemGroup>

</Project>
```

And the versions in the dependencies file:
```xml
<?xml version="1.0" encoding="utf-8"?>
<Project>
  <PropertyGroup>
    <NetCoreVersion>8.0.3</NetCoreVersion>
    <NetAnalyzersVersion>8.0.0</NetAnalyzersVersion>
    <RoslynatorVersion>4.11.0</RoslynatorVersion>
    <OpenTelemetryVersion>1.7.0</OpenTelemetryVersion>
    <OpenTelemetryInstrumentationVersion>$(OpenTelemetryVersion)</OpenTelemetryInstrumentationVersion>
  </PropertyGroup>
  <ItemGroup Label="Microsoft">
    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(NetCoreVersion)" />
    <PackageReference Update="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
  </ItemGroup>
  <ItemGroup Label="Others">
    <PackageReference Update="Swashbuckle.AspNetCore" Version="6.5.0" />
    <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
    <PackageReference Update="Mediatr" Version="12.2.0" />
    <PackageReference Update="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
    <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
    <PackageReference Update="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryVersion)" />
    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationVersion)" />
    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationVersion)" />
  </ItemGroup>
</Project>
```

The new DependencyFileAddPackageService will only update the versions in the properties file.
To run with the DependencyFileAddPackageService you provide the new option
```cs
[Option(CommandOptionType.SingleValue, Description = "Use a dependencies update file. csproj files will remain unmodified",
            ShortName = "dpf", LongName = "dependency-file")]
```

I also refactored the Program.cs a bit to simplify testing with mocked out components