### PR TITLE
Fix XML query for Project SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: Test
 
 on: [pull_request, workflow_dispatch]
 
+env:
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  FORCE_COLOR: 3
+  TERM: xterm
+
 jobs:
   # build-warnings:
   #   name: Build warnings check

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -319,7 +319,17 @@ namespace DotNetOutdated
             try
             {
                var xml = XDocument.Load(projectFilePath);
-               return xml.Descendants("Project")
+
+               // If the project file declares the xmlns attribute, we need to account for it in queries for elements.
+               // Otherwise the query will return no results and the project type will be misidentified.
+               // e.g. <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
+               XNamespace ns = string.Empty;
+               if (xml.Root != null)
+               {
+                  ns = xml.Root.GetDefaultNamespace();
+               }
+
+               return xml.Descendants(ns + "Project")
                   .Any(e => !string.IsNullOrEmpty(e.Attribute("Sdk")?.Value));
             }
             catch (Exception ex)

--- a/src/DotNetOutdated/ProjectExtensions.cs
+++ b/src/DotNetOutdated/ProjectExtensions.cs
@@ -67,18 +67,16 @@ namespace DotNetOutdated
             {
                 var xml = XDocument.Load(project.ProjectFilePath);
 
+                if (xml.Root == null)
+                {
+                    return false;
+                }
+
                 // If the project file declares the xmlns attribute, we need to account for it in queries for elements.
                 // Otherwise the query will return no results and the project type will be misidentified.
                 // e.g. <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
-                XNamespace ns = string.Empty;
-                if (xml.Root != null)
-                {
-                    ns = xml.Root.GetDefaultNamespace();
-                }
-
-                return xml
-                    .Descendants(ns + "Project")
-                    .Any(e => !string.IsNullOrEmpty(e.Attribute("Sdk")?.Value));
+                XNamespace ns = xml.Root.GetDefaultNamespace();
+                return xml.Root.Name == (ns + "Project") && !string.IsNullOrEmpty(xml.Root.Attribute("Sdk")?.Value);
             }
             catch (Exception ex)
             {

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -6,12 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.64" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/DotNetOutdated.Tests/ProjectExtensionsTests.cs
+++ b/test/DotNetOutdated.Tests/ProjectExtensionsTests.cs
@@ -150,7 +150,5 @@ public static class ProjectExtensionsTests
                 // Ignore
             }
         }
-
-        public bool Exists() => File.Exists(Path);
     }
 }

--- a/test/DotNetOutdated.Tests/ProjectExtensionsTests.cs
+++ b/test/DotNetOutdated.Tests/ProjectExtensionsTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotNetOutdated.Tests;
+
+public static class ProjectExtensionsTests
+{
+    public static TheoryData<string, bool> ProjectContents()
+    {
+        var testCases = new TheoryData<string, bool>();
+
+        testCases.Add(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+            </Project>
+            """,
+            true);
+
+        testCases.Add(
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+            </Project>
+            """,
+            true);
+
+        testCases.Add(
+            """
+            <Project Sdk="MSTest.Sdk">
+            </Project>
+            """,
+            true);
+
+        testCases.Add(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project Sdk="Microsoft.NET.Sdk">
+            </Project>
+            """,
+            true);
+
+        testCases.Add(
+            """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
+            </Project>
+            """,
+            true);
+
+        testCases.Add(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
+            </Project>
+            """,
+            true);
+
+        testCases.Add(
+            """
+            <Project>
+            </Project>
+            """,
+            false);
+
+        testCases.Add(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project>
+            </Project>
+            """,
+            false);
+
+        testCases.Add(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project ToolsVersion="14.0">
+            </Project>
+            """,
+            false);
+
+        testCases.Add(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+            </Project>
+            """,
+            false);
+
+        return testCases;
+    }
+
+    [Theory]
+    [MemberData(nameof(ProjectContents))]
+    public static async Task IsProjectSdkStyle_Returns_Correct_Value(string contents, bool expected)
+    {
+        // Arrange
+        using var file = new TemporaryFile();
+        var project = new PackageProjectReference()
+        {
+            ProjectFilePath = file.Path,
+        };
+
+        await File.WriteAllTextAsync(file.Path, contents);
+
+        // Act
+        var actual = project.IsProjectSdkStyle();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    private sealed class TemporaryFile : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.GetTempFileName();
+
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(Path);
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+        }
+
+        public bool Exists() => File.Exists(Path);
+    }
+}

--- a/test/DotNetOutdated.Tests/ProjectExtensionsTests.cs
+++ b/test/DotNetOutdated.Tests/ProjectExtensionsTests.cs
@@ -86,6 +86,32 @@ public static class ProjectExtensionsTests
             """,
             false);
 
+        testCases.Add(
+            """
+            <Foo></Foo>
+            """,
+            false);
+
+        testCases.Add(
+            """
+            <Foo Sdk="Microsoft.NET.Sdk"></Foo>
+            """,
+            false);
+
+        testCases.Add(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Foo>
+            </Foo>
+            """,
+            false);
+
+        testCases.Add(
+            """
+            Not XML
+            """,
+            false);
+
         return testCases;
     }
 


### PR DESCRIPTION
Fix XML query incorrectly identifying a project file as a non-SDK style project if it contains an `xmlns` attribute.

I discovered this through https://github.com/martincostello/dotnet-bumper/pull/228 where I switched to using the MSBuildProjectCreator library to create test projects, which are always emitted with the MSBuild namespace. After doing this, the some of the tests would fail due to dotnet outdated failing to update packages correctly as it was misidentifying the projects as non-SDK projects:

```console
Project format not SDK style, removing package before upgrade.
```

For now, I've worked around this by manually removing the `xmlns` value from the projects the tests create: https://github.com/martincostello/dotnet-bumper/pull/228/commits/42468393cab4cf36c71e3d71c5fea03593d499ec

I haven't yet tested this change and there didn't seem to be any specific unit tests regarding this check. It's based on the same approach I already used this to handle this myself ([example](https://github.com/martincostello/dotnet-bumper/blob/3f5b7b7271774af8902387b5888166ea1de9e11c/src/DotNetBumper.Core/ProjectHelpers.cs#L55-L64)) which I also had to use in the PR referenced above itself to fix my own tests with the added `xmlns`.
