### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3.2.0
+        uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
             6.0.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 30
   #   steps:
-  #     - uses: actions/checkout@v3.5.3
+  #     - uses: actions/checkout@v4.1.3
 
   #     - name: Build
   #       run: dotnet build /WarnAsError
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3.5.3
+    - uses: actions/checkout@v4.1.3
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3.2.0
+      uses: actions/setup-dotnet@v4.0.0
       with:
         dotnet-version: | 
             6.0.x


### PR DESCRIPTION
Bump actions to latest versions to resolve [Node.js v16 deprecation warnings](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

