### PR TITLE
enforce CA2007 for performance

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,2 @@
+[*.{cs,vb}]
+dotnet_diagnostic.CA2007.severity = error

--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -42,7 +42,7 @@ namespace DotNetOutdated.Core.Services
 
             if (runStatus.IsSuccess)
             {
-                var dependencyGraphText = await _fileSystem.File.ReadAllTextAsync(dgOutput);
+                var dependencyGraphText = await _fileSystem.File.ReadAllTextAsync(dgOutput).ConfigureAwait(false);
                 return new ExtendedDependencyGraphSpec(dependencyGraphText);
             }
 

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -26,7 +26,7 @@ namespace DotNetOutdated.Core.Services
 
         public async Task<List<Project>> AnalyzeProjectAsync(string projectPath, bool runRestore, bool includeTransitiveDependencies, int transitiveDepth)
         {
-            var dependencyGraph = await _dependencyGraphService.GenerateDependencyGraphAsync(projectPath);
+            var dependencyGraph = await _dependencyGraphService.GenerateDependencyGraphAsync(projectPath).ConfigureAwait(false);
             if (dependencyGraph == null)
                 return null;
 

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -116,9 +116,9 @@ namespace DotNetOutdated
           ShortName = "prl", LongName = "pre-release-label")]
       public string PrereleaseLabel { get; set; } = string.Empty;
 
-      public static int Main(string[] args)
+      public static async Task<int> Main(string[] args)
       {
-         using var services = new ServiceCollection()
+         var services = new ServiceCollection()
                  .AddSingleton<IConsole>(PhysicalConsole.Singleton)
                  .AddSingleton<IReporter>(provider => new ConsoleReporter(provider.GetService<IConsole>()))
                  .AddSingleton<IFileSystem, FileSystem>()
@@ -133,12 +133,15 @@ namespace DotNetOutdated
                  .AddSingleton<ICentralPackageVersionManagementService, CentralPackageVersionManagementService>()
                  .BuildServiceProvider();
 
-         using var app = new CommandLineApplication<Program>();
-         app.Conventions
-             .UseDefaultConventions()
-             .UseConstructorInjection(services);
+         await using (services.ConfigureAwait(false))
+         {
+            using var app = new CommandLineApplication<Program>();
+            app.Conventions
+               .UseDefaultConventions()
+               .UseConstructorInjection(services);
 
-         return app.Execute(args);
+            return app.Execute(args);
+         }
       }
 
       public static string GetVersion() => typeof(Program)

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -186,7 +186,7 @@ namespace DotNetOutdated
             // Analyze the projects
             console.Write("Analyzing project(s)...");
 
-            var projectLists = await Task.WhenAll(projectPaths.Select(path => _projectAnalysisService.AnalyzeProjectAsync(path, false, Transitive, TransitiveDepth)));
+            var projectLists = await Task.WhenAll(projectPaths.Select(path => _projectAnalysisService.AnalyzeProjectAsync(path, false, Transitive, TransitiveDepth))).ConfigureAwait(false);
             var projects = projectLists.SelectMany(p => p).ToList();
 
             if (!console.IsOutputRedirected)

--- a/src/DotNetOutdated/Services/ReportHelpers.cs
+++ b/src/DotNetOutdated/Services/ReportHelpers.cs
@@ -19,7 +19,7 @@ namespace DotNetOutdated.Services
         {
             using (FileStream createStream = File.Create(filename))
             {
-                await JsonSerializer.SerializeAsync(createStream, projects);
+                await JsonSerializer.SerializeAsync(createStream, projects).ConfigureAwait(false);
             }
         }
     }

--- a/src/DotNetOutdated/Services/ReportHelpers.cs
+++ b/src/DotNetOutdated/Services/ReportHelpers.cs
@@ -17,7 +17,8 @@ namespace DotNetOutdated.Services
     {
         public async Task WriteReport(string filename, List<Project> projects)
         {
-            using (FileStream createStream = File.Create(filename))
+            var createStream = File.Create(filename);
+            await using (createStream.ConfigureAwait(false))
             {
                 await JsonSerializer.SerializeAsync(createStream, projects).ConfigureAwait(false);
             }

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DotNetOutdated.Tests;
@@ -12,7 +13,7 @@ public static class EndToEndTests
     [InlineData("build-props")]
     [InlineData("development-dependencies")]
     [InlineData("multi-target", Skip = "Fails on Windows in GitHub Actions for some reason.")]
-    public static void Can_Upgrade_Project(string name)
+    public static async Task Can_Upgrade_Project(string name)
     {
         var solutionRoot = typeof(EndToEndTests).Assembly
             .GetCustomAttributes<AssemblyMetadataAttribute>().First((p) => p.Key is "SolutionRoot")
@@ -28,7 +29,7 @@ public static class EndToEndTests
             File.Copy(source, destination);
         }
 
-        var actual = Program.Main([projectPath]);
+        var actual = await Program.Main([projectPath]);
         Assert.Equal(0, actual);
     }
 


### PR DESCRIPTION
Ensures that ConfigureAwait() is always specified. This is good to enforce for performance and consistency in the context of a console tool like this.

see also: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007