### PR TITLE
Async Formatters for performance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/DotNetOutdated/Formatters/CsvFormatter.cs
+++ b/src/DotNetOutdated/Formatters/CsvFormatter.cs
@@ -4,35 +4,41 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace DotNetOutdated.Formatters;
 
 internal class CsvFormatter : IOutputFormatter
 {
-    public void Format(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
+    public async Task FormatAsync(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
     {
-        using var csv = new CsvWriter(writer, CultureInfo.CurrentCulture);
-        foreach (var project in projects)
+        var csv = new CsvWriter(writer, CultureInfo.CurrentCulture);
+        await using (csv.ConfigureAwait(false))
         {
-            foreach (var targetFramework in project.TargetFrameworks)
-            {
-                foreach (var dependency in targetFramework.Dependencies)
-                {
-                    var upgradeSeverity = Enum.GetName(dependency.UpgradeSeverity);
+            List<CsvDependency> records = [];
 
-                    csv.WriteRecord(new
+            foreach (var project in projects)
+            {
+                foreach (var targetFramework in project.TargetFrameworks)
+                {
+                    foreach (var dependency in targetFramework.Dependencies)
                     {
-                        ProjectName = project.Name,
-                        TargetFrameworkName = targetFramework.Name.DotNetFrameworkName,
-                        DependencyName = dependency.Name,
-                        ResolvedVersion = dependency.ResolvedVersion?.ToString(),
-                        LatestVersion = dependency.LatestVersion?.ToString(),
-                        UpgradeSeverity = upgradeSeverity
-                    });
-                    csv.NextRecord();
+                        var upgradeSeverity = Enum.GetName(dependency.UpgradeSeverity);
+
+                        records.Add(new CsvDependency
+                        {
+                            ProjectName = project.Name,
+                            TargetFrameworkName = targetFramework.Name.DotNetFrameworkName,
+                            DependencyName = dependency.Name,
+                            ResolvedVersion = dependency.ResolvedVersion?.ToString(),
+                            LatestVersion = dependency.LatestVersion?.ToString(),
+                            UpgradeSeverity = upgradeSeverity
+                        });
+                    }
                 }
             }
-        }
 
+            await csv.WriteRecordsAsync(records).ConfigureAwait(false);
+        }
     }
 }

--- a/src/DotNetOutdated/Formatters/JsonFormatter.cs
+++ b/src/DotNetOutdated/Formatters/JsonFormatter.cs
@@ -1,23 +1,26 @@
 ﻿using DotNetOutdated.Models;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace DotNetOutdated.Formatters;
 
 internal class JsonFormatter : IOutputFormatter
 {
-    public void Format(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
+    private static readonly JsonSerializerOptions jsonSerializerOptions = new() { WriteIndented = true };
+
+    public async Task FormatAsync(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
     {
         var report = new Report
         {
             Projects = projects
         };
-        JsonSerializer serializer = JsonSerializer.CreateDefault(default);
-        serializer.Formatting = Formatting.Indented;
-        serializer.Serialize(writer, report);
+
+        var json = JsonSerializer.Serialize(report, jsonSerializerOptions);
+        await writer.WriteAsync(json).ConfigureAwait(false);
     }
 
     private class Report

--- a/src/DotNetOutdated/IOutputFormatter.cs
+++ b/src/DotNetOutdated/IOutputFormatter.cs
@@ -1,10 +1,11 @@
 ﻿using DotNetOutdated.Models;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace DotNetOutdated;
 
 internal interface IOutputFormatter
 {
-    void Format(IReadOnlyList<AnalyzedProject> projects,TextWriter writer);
+    Task FormatAsync(IReadOnlyList<AnalyzedProject> projects,TextWriter writer);
 }

--- a/src/DotNetOutdated/Models/AnalyzedProject.cs
+++ b/src/DotNetOutdated/Models/AnalyzedProject.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using DotNetOutdated.Core.Models;
 using DotNetOutdated.Services;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using NuGet.Frameworks;
 using NuGet.Versioning;
@@ -11,10 +10,13 @@ namespace DotNetOutdated.Models
 {
     public class AnalyzedProject
     {
+        [JsonPropertyOrder(2)]
         public IReadOnlyList<AnalyzedTargetFramework> TargetFrameworks { get; }
 
+        [JsonPropertyOrder(0)]
         public string Name { get; set; }
 
+        [JsonPropertyOrder(1)]
         public string FilePath { get; set; }
 
         public AnalyzedProject(string name, string filePath, IEnumerable<AnalyzedTargetFramework> targetFrameworks)
@@ -27,8 +29,10 @@ namespace DotNetOutdated.Models
 
     public class AnalyzedTargetFramework
     {
+        [JsonPropertyOrder(1)]
         public IReadOnlyList<AnalyzedDependency> Dependencies { get; }
 
+        [JsonPropertyOrder(0)]
         [JsonConverter(typeof(ToStringJsonConverter))]
         public NuGetFramework Name { get; set; }
 
@@ -68,14 +72,18 @@ namespace DotNetOutdated.Models
         [JsonIgnore]
         public bool IsVersionCentrallyManaged => _dependency.IsVersionCentrallyManaged;
 
+        [JsonPropertyOrder(0)]
         public string Name => _dependency.Name;
 
+        [JsonPropertyOrder(1)]
         [JsonConverter(typeof(ToStringJsonConverter))]
         public NuGetVersion ResolvedVersion => _dependency.ResolvedVersion;
 
+        [JsonPropertyOrder(2)]
         [JsonConverter(typeof(ToStringJsonConverter))]
         public NuGetVersion LatestVersion { get; set; }
 
+        [JsonPropertyOrder(3)]
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public DependencyUpgradeSeverity UpgradeSeverity
         {

--- a/src/DotNetOutdated/Models/AnalyzedProject.cs
+++ b/src/DotNetOutdated/Models/AnalyzedProject.cs
@@ -105,4 +105,14 @@ namespace DotNetOutdated.Models
             LatestVersion = latestVersion;
         }
     }
+
+    public class CsvDependency
+    {
+        public string ProjectName { get; set; }
+        public string TargetFrameworkName { get; set; }
+        public string DependencyName { get; set; }
+        public string ResolvedVersion { get; set; }
+        public string LatestVersion { get; set; }
+        public string UpgradeSeverity { get; set; }
+    }
 }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -88,7 +88,7 @@ namespace DotNetOutdated
       public string OutputFilename { get; set; } = null;
 
       [Option(CommandOptionType.SingleValue, Description = "Specifies the output format for the generated report. " +
-                                                           "Possible values: json (default) or csv.",
+                                                           "Possible values: json (default), csv, or markdown. 0, 1, or 2 respectively",
           ShortName = "of", LongName = "output-format")]
       public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
 

--- a/test/DotNetOutdated.Tests/JsonFormatterTests.cs
+++ b/test/DotNetOutdated.Tests/JsonFormatterTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using DotNetOutdated.Core.Models;
+using DotNetOutdated.Formatters;
+using DotNetOutdated.Models;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using Xunit;
+
+namespace DotNetOutdated.Tests;
+
+public class JsonFormatterTests
+{
+    [Fact]
+    public async Task JsonFormatterReportOutput()
+    {
+        // Testing the JSON format, as the output is effectively a contract
+      
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+        
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Http.Diagnostics", new VersionRange(new NuGetVersion("9.0.0-preview.4.24261.1")), new NuGetVersion("9.0.0-preview.4.24261.1"), false, false, false, true), new NuGetVersion("9.0.0-preview.4.24263.5")),
+                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Http.Resilience", new VersionRange(new NuGetVersion("9.0.0-preview.4.24261.1")), new NuGetVersion("9.0.0-preview.4.24261.1"), false, false, false, true), new NuGetVersion("9.0.0-preview.4.24263.5")),
+                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Telemetry", new VersionRange(new NuGetVersion("9.0.0-preview.4.24261.1")), new NuGetVersion("9.0.0-preview.4.24261.1"), false, false, false, true), new NuGetVersion("9.0.0-preview.4.24263.5"))
+                })
+            })
+        ];
+        
+        var json = new JsonFormatter();
+        await json.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          {
+            "Projects": [
+              {
+                "Name": "TweetiePie",
+                "FilePath": "C:\\Coding\\codeflow\\tweetiepie\\src\\TweetiePie\\TweetiePie.csproj",
+                "TargetFrameworks": [
+                  {
+                    "Name": "net9.0",
+                    "Dependencies": [
+                      {
+                        "Name": "Microsoft.Extensions.Http.Diagnostics",
+                        "ResolvedVersion": "9.0.0-preview.4.24261.1",
+                        "LatestVersion": "9.0.0-preview.4.24263.5",
+                        "UpgradeSeverity": "Major"
+                      },
+                      {
+                        "Name": "Microsoft.Extensions.Http.Resilience",
+                        "ResolvedVersion": "9.0.0-preview.4.24261.1",
+                        "LatestVersion": "9.0.0-preview.4.24263.5",
+                        "UpgradeSeverity": "Major"
+                      },
+                      {
+                        "Name": "Microsoft.Extensions.Telemetry",
+                        "ResolvedVersion": "9.0.0-preview.4.24261.1",
+                        "LatestVersion": "9.0.0-preview.4.24263.5",
+                        "UpgradeSeverity": "Major"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+          """;
+        
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+}

--- a/test/DotNetOutdated.Tests/JsonFormatterTests.cs
+++ b/test/DotNetOutdated.Tests/JsonFormatterTests.cs
@@ -20,6 +20,9 @@ public class JsonFormatterTests
       
         var stringBuilder = new StringBuilder();
         var textWriter = new StringWriter(stringBuilder);
+
+        var previewVersion = new NuGetVersion("9.0.0-preview.4.24261.1");
+        var newerPreviewVersion = new NuGetVersion("9.0.0-preview.4.24263.5");
         
         List<AnalyzedProject> analyzedProjects =
         [
@@ -27,9 +30,9 @@ public class JsonFormatterTests
             {
                 new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
                 {
-                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Http.Diagnostics", new VersionRange(new NuGetVersion("9.0.0-preview.4.24261.1")), new NuGetVersion("9.0.0-preview.4.24261.1"), false, false, false, true), new NuGetVersion("9.0.0-preview.4.24263.5")),
-                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Http.Resilience", new VersionRange(new NuGetVersion("9.0.0-preview.4.24261.1")), new NuGetVersion("9.0.0-preview.4.24261.1"), false, false, false, true), new NuGetVersion("9.0.0-preview.4.24263.5")),
-                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Telemetry", new VersionRange(new NuGetVersion("9.0.0-preview.4.24261.1")), new NuGetVersion("9.0.0-preview.4.24261.1"), false, false, false, true), new NuGetVersion("9.0.0-preview.4.24263.5"))
+                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Http.Diagnostics", new VersionRange(previewVersion), previewVersion, false, false, false, true), newerPreviewVersion),
+                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Http.Resilience", new VersionRange(previewVersion), previewVersion, false, false, false, true), newerPreviewVersion),
+                    new AnalyzedDependency(new Dependency("Microsoft.Extensions.Telemetry", new VersionRange(previewVersion), previewVersion, false, false, false, true), newerPreviewVersion)
                 })
             })
         ];


### PR DESCRIPTION
This should help with performance. Also one remaining Newtonsoft reference was replaced with System.Text.Json

The `await using (something.ConfigureAwait(false))` pattern will help allow IAsyncDisposable to be used in conjunction with CA2007. See [this thread](https://stackoverflow.com/questions/69905541/getting-ca2007-after-upgrading-to-6-0-version-of-the-roslyn-analyzers) for details.
 
Needed to add a .gitattributes file so that this could produce a good diff. Otherwise, all the line endings are screwed up