### PR TITLE
Cleanup tests

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -88,7 +88,7 @@ namespace DotNetOutdated
       public string OutputFilename { get; set; } = null;
 
       [Option(CommandOptionType.SingleValue, Description = "Specifies the output format for the generated report. " +
-                                                           "Possible values: json (default), csv, or markdown. 0, 1, or 2 respectively",
+                                                           "Possible values: json (default), csv, or markdown.",
           ShortName = "of", LongName = "output-format")]
       public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
 

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using Xunit;
 
 namespace DotNetOutdated.Tests;
@@ -57,7 +58,9 @@ public class EndToEndTests : IDisposable
         foreach (var source in Directory.GetFiles(projectPath, "*", SearchOption.TopDirectoryOnly))
         {
             string destination = Path.Combine(_tempDirectory.Path, Path.GetFileName(source));
-            File.Copy(source, destination);
+            // Copy the file as UTF-8
+            var fileContent = File.ReadAllText(source, Encoding.UTF8);
+            File.WriteAllText(destination, fileContent, Encoding.UTF8);
         }
     }
 

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -23,7 +23,7 @@ public class EndToEndTests : IDisposable
     [Theory]
     [InlineData("build-props")]
     [InlineData("development-dependencies")]
-    [InlineData("multi-target", Skip = "Fails on Windows in GitHub Actions for some reason.")]
+    [InlineData("multi-target")]
     public void Can_Upgrade_Project(string testProjectName)
     {
         TestSetup(testProjectName);


### PR DESCRIPTION
I realized these tests were working despite something that seemed silly. I had moved the TemporaryDirectory creation inside of a test setup method, and it was wrapped in a using statement.

The using statement will call dispose at the end of the method and that deletes the temporary directory.

But the tests still pass and the output file is generated correctly. Because the true project path was always being used, and not the temporary files.

So, this means the temporary directory is useless and only makes the tests slower.

Also fixed a confusing comment that I had made that @martincostello pointed out.