### PR TITLE
Add `--disable-legend` option to disable the 'Version color legend' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Options:
   -r|--recursive                             Recursively search for all projects within the provided directory.
   -ifs|--ignore-failed-sources               Treat package source failures as warnings.
   -utd|--include-up-to-date                  Include all dependencies in the report even the ones not outdated.
+  -dl|--disable-legend                       Disable legend in command output.
 ```
 
 ![Screenshot of dotnet-outdated](screenshot.png)

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -126,6 +126,10 @@ namespace DotNetOutdated
          ShortName = "rt", LongName = "runtime")]
       public string Runtime { get; set; } = string.Empty;
       
+      [Option(CommandOptionType.NoValue, Description = "Disable legend in command output",
+         ShortName = "dl", LongName = "disable-legend")]
+      public bool DisableLegend { get; set; } = false;
+      
         public static int Main(string[] args)
       {
          using var services = new ServiceCollection()
@@ -200,7 +204,7 @@ namespace DotNetOutdated
             if (outdatedProjects.Any())
             {
                // Report on the outdated dependencies
-               ReportOutdatedDependencies(outdatedProjects, console);
+               ReportOutdatedDependencies(outdatedProjects, console, DisableLegend);
 
                // Upgrade the packages
                var success = UpgradePackages(outdatedProjects, console);
@@ -361,7 +365,7 @@ namespace DotNetOutdated
          console.Write(rest, GetUpgradeSeverityColor(upgradeSeverity));
       }
 
-      private static void ReportOutdatedDependencies(List<AnalyzedProject> projects, IConsole console)
+      private static void ReportOutdatedDependencies(List<AnalyzedProject> projects, IConsole console, bool legendDisabled)
       {
          foreach (var project in projects)
          {
@@ -405,7 +409,10 @@ namespace DotNetOutdated
             console.WriteLine();
          }
 
-         PrintColorLegend(console);
+         if (!legendDisabled)
+         {
+            PrintColorLegend(console);
+         }
       }
 
       private async Task<List<AnalyzedProject>> AnalyzeDependencies(List<Project> projects, IConsole console)


### PR DESCRIPTION
As the title described, I added an option to disable the legend in the output.

I mainly use this tool in scripts to get a quick overview of local repositories (for example, to validate that renovate is catching all updates and to determine the overall Nuget status in projects).
Having the legend 20 times in the shell output makes it a bit unreadable (but this is just my use case).

If you think this can be useful overall, I would be happy if you accepted the change.

Please let me know if you have any suggestions for improvement (especially variable names or similar).