### PR TITLE
Add HTML Formatter and Tests

### DIFF
--- a/src/DotNetOutdated/Formatters/HtmlFormatter.cs
+++ b/src/DotNetOutdated/Formatters/HtmlFormatter.cs
@@ -1,0 +1,112 @@
+﻿#nullable enable
+using DotNetOutdated.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace DotNetOutdated.Formatters;
+
+internal class HtmlFormatter : IOutputFormatter
+{
+    static readonly Dictionary<DependencyUpgradeSeverity, string?> _colorMaps = new()
+    {
+        {DependencyUpgradeSeverity.None,default},
+        {DependencyUpgradeSeverity.Patch,"green"},
+        {DependencyUpgradeSeverity.Minor,"orange"},
+        {DependencyUpgradeSeverity.Major,"red"},
+        {DependencyUpgradeSeverity.Unknown,default},
+    };
+
+    public async Task FormatAsync(IReadOnlyList<AnalyzedProject> projects, TextWriter writer)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("<h1>Outdated Packages</h1>");
+        foreach (var project in projects.OrderBy(p => p.Name))
+        {
+            sb.AppendLine($"<h2>{project.Name}</h2>");
+            foreach (var targetFramework in project.TargetFrameworks)
+            {
+                sb.AppendLine($"<h3>Target:{targetFramework.Name}</h3>");
+                sb.AppendLine("<table><thead><tr>");
+
+                // Headers
+                sb.AppendLine("<th>Package</th>");
+                sb.AppendLine("<th>Transitive</th>");
+                sb.AppendLine("<th style=\"text-align: right;\">Current</th>");
+                sb.AppendLine("<th style=\"text-align: right;\">Last</th>");
+                sb.AppendLine("<th style=\"text-align: right;\">Severity</th>");
+                sb.AppendLine("</tr></thead>");
+
+                // Body
+                sb.AppendLine("<tbody>");
+                foreach (var dependency in targetFramework.Dependencies)
+                {
+                    sb.AppendLine("<tr>");
+                    sb.AppendLine("<td>" + dependency.Name + "</td>");
+                    sb.AppendLine("<td>" + dependency.IsTransitive.ToString() + "</td>");
+                    sb.AppendLine("<td style=\"text-align: right;\">" + dependency.ResolvedVersion + "</td>");
+
+                    sb.Append("<td style=\"text-align: right;\">");
+                    if (dependency.LatestVersion != null)
+                    {
+                        if (dependency.ResolvedVersion == null || dependency.ResolvedVersion.Equals(dependency.LatestVersion))
+                            sb.Append("<span>" + dependency.LatestVersion + "</span>");
+                        else
+                            RenderUpdatableDependency(sb, dependency);
+                    }
+                    sb.AppendLine("</td>");
+                    sb.AppendLine("<td style=\"text-align: right;\">" + dependency.UpgradeSeverity + "</td>");
+                    sb.AppendLine("</tr>");
+                }
+                sb.AppendLine("</tbody></table>");
+            }
+        }
+
+        // Note
+        sb.AppendLine("<blockquote>");
+        sb.AppendLine("<p><strong>Note</strong></p>");
+        sb.AppendLine("<p>🔴: Major version update or pre-release version. Possible breaking changes.</p>");
+        sb.AppendLine("<p>🟠: Minor version update. Backwards-compatible features added.</p>");
+        sb.AppendLine("<p>🟢: Patch version update. Backwards-compatible bug fixes.</p>");
+        sb.AppendLine("</blockquote>");
+
+        await writer.WriteAsync(sb.ToString()).ConfigureAwait(false);
+    }
+
+    private static void RenderUpdatableDependency(StringBuilder sb, AnalyzedDependency dependency)
+    {
+        var latestString = dependency.LatestVersion.ToString();
+        var colour = _colorMaps[dependency.UpgradeSeverity];
+
+        if (dependency.ResolvedVersion.IsPrerelease)
+            WriteSpanWithColour(sb, colour, latestString);
+
+        var matching = string.Join(".", dependency.ResolvedVersion.GetParts()
+            .Zip(dependency.LatestVersion.GetParts(), (p1, p2) => (part: p2, matches: p1 == p2))
+            .TakeWhile(p => p.matches)
+            .Select(p => p.part));
+        if (matching.Length > 0) { matching += "."; }
+        var rest = latestString.Substring(matching.Length).ToString();
+
+        sb.Append("<span>");
+        sb.Append(matching);
+        sb.Append("</span>");
+
+        if (!string.IsNullOrEmpty(rest))
+            WriteSpanWithColour(sb, colour, rest);
+    }
+
+    private static void WriteSpanWithColour(StringBuilder sb, string? colour, string text)
+    {
+        sb.Append("<span style=\"color:");
+        sb.Append(colour);
+        sb.Append(";font-weight:bold\">");
+        sb.Append(text);
+        sb.Append("</span>");
+    }
+}

--- a/src/DotNetOutdated/OutputFormat.cs
+++ b/src/DotNetOutdated/OutputFormat.cs
@@ -4,6 +4,7 @@
     {
         Json,
         Csv,
-        Markdown
+        Markdown,
+        Html
     }
 }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -88,7 +88,7 @@ namespace DotNetOutdated
       public string OutputFilename { get; set; } = null;
 
       [Option(CommandOptionType.SingleValue, Description = "Specifies the output format for the generated report. " +
-                                                           "Possible values: json (default), csv, or markdown.",
+                                                           "Possible values: json (default), csv, markdown, or html.",
           ShortName = "of", LongName = "output-format")]
       public OutputFormat OutputFileFormat { get; set; } = OutputFormat.Json;
 
@@ -564,7 +564,8 @@ namespace DotNetOutdated
                {
                   OutputFormat.Csv => new Formatters.CsvFormatter(),
                   OutputFormat.Markdown => new Formatters.MarkdownFormatter(),
-                  _ => new Formatters.JsonFormatter(),
+                  OutputFormat.Html => new Formatters.HtmlFormatter(),
+                   _ => new Formatters.JsonFormatter(),
                };
                await formatter.FormatAsync(projects, sw).ConfigureAwait(false);
                Console.WriteLine($"Report written to {OutputFilename}");

--- a/test/DotNetOutdated.Tests/HtmlFormatterTests.cs
+++ b/test/DotNetOutdated.Tests/HtmlFormatterTests.cs
@@ -1,0 +1,471 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using DotNetOutdated.Core.Models;
+using DotNetOutdated.Formatters;
+using DotNetOutdated.Models;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using Xunit;
+
+namespace DotNetOutdated.Tests;
+
+public class HtmlFormatterTests
+{
+    private const string _noteString =
+        """
+        <blockquote>
+        <p><strong>Note</strong></p>
+        <p>🔴: Major version update or pre-release version. Possible breaking changes.</p>
+        <p>🟠: Minor version update. Backwards-compatible features added.</p>
+        <p>🟢: Patch version update. Backwards-compatible bug fixes.</p>
+        </blockquote>
+
+        """;
+
+    [Fact]
+    public async Task NoUpdatesShowsCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        var previewVersion = new NuGetVersion(new System.Version(1, 2, 3, 4));
+        var newerPreviewVersion = new NuGetVersion(new System.Version(1, 2, 3, 4));
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(previewVersion), previewVersion, false, false, false, true), newerPreviewVersion)
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">1.2.3.4</td>
+          <td style="text-align: right;"><span>1.2.3.4</span></td>
+          <td style="text-align: right;">None</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task PatchUpdateShowsCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        var resolvedVersion = new NuGetVersion(new System.Version(1, 2, 2, 4));
+        var latestVersion = new NuGetVersion(new System.Version(1, 2, 3, 4));
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(resolvedVersion), resolvedVersion, false, false, false, true), latestVersion)
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">1.2.2.4</td>
+          <td style="text-align: right;"><span>1.2.</span><span style="color:green;font-weight:bold">3.4</span></td>
+          <td style="text-align: right;">Patch</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task MinorUpdateShowsCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        var resolvedVersion = new NuGetVersion(new System.Version(1, 1, 3, 4));
+        var latestVersion = new NuGetVersion(new System.Version(1, 2, 3, 4));
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(resolvedVersion), resolvedVersion, false, false, false, true), latestVersion)
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">1.1.3.4</td>
+          <td style="text-align: right;"><span>1.</span><span style="color:orange;font-weight:bold">2.3.4</span></td>
+          <td style="text-align: right;">Minor</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task MajorUpdateShowsCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        var resolvedVersion = new NuGetVersion(new System.Version(0, 2, 3, 4));
+        var latestVersion = new NuGetVersion(new System.Version(1, 2, 3, 4));
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(resolvedVersion), resolvedVersion, false, false, false, true), latestVersion)
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">0.2.3.4</td>
+          <td style="text-align: right;"><span></span><span style="color:red;font-weight:bold">1.2.3.4</span></td>
+          <td style="text-align: right;">Major</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task NotCentrallyUpdatedShowsCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        var resolvedVersion = new NuGetVersion(new System.Version(1, 2, 3));
+        var latestVersion = new NuGetVersion(new System.Version(1, 3, 4));
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(resolvedVersion), resolvedVersion, false, false, false, false), latestVersion)
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">1.2.3</td>
+          <td style="text-align: right;"><span>1.</span><span style="color:orange;font-weight:bold">3.4</span></td>
+          <td style="text-align: right;">Minor</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task MultipleUpdatesShowCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(new NuGetVersion(9, 0, 1)), new NuGetVersion(9, 0, 1), false, false, false, false), new NuGetVersion(9, 1, 2)),
+                    new AnalyzedDependency(new Dependency("Package.Example.Client", new VersionRange(new NuGetVersion(6, 2, 8)), new NuGetVersion(6, 2, 8), false, false, false, false), new NuGetVersion(6, 2, 9))
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">9.0.1</td>
+          <td style="text-align: right;"><span>9.</span><span style="color:orange;font-weight:bold">1.2</span></td>
+          <td style="text-align: right;">Minor</td>
+          </tr>
+          <tr>
+          <td>Package.Example.Client</td>
+          <td>False</td>
+          <td style="text-align: right;">6.2.8</td>
+          <td style="text-align: right;"><span>6.2.</span><span style="color:green;font-weight:bold">9</span></td>
+          <td style="text-align: right;">Patch</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task MultipleFrameworksShowCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(new NuGetVersion(9, 0, 1)), new NuGetVersion(9, 0, 1), false, false, false, false), new NuGetVersion(9, 1, 2)),
+                }),
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net8.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(new NuGetVersion(9, 0, 1)), new NuGetVersion(9, 0, 1), false, false, false, false), new NuGetVersion(9, 1, 2)),
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">9.0.1</td>
+          <td style="text-align: right;"><span>9.</span><span style="color:orange;font-weight:bold">1.2</span></td>
+          <td style="text-align: right;">Minor</td>
+          </tr>
+          </tbody></table>
+          <h3>Target:net8.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">9.0.1</td>
+          <td style="text-align: right;"><span>9.</span><span style="color:orange;font-weight:bold">1.2</span></td>
+          <td style="text-align: right;">Minor</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+
+    [Fact]
+    public async Task MultipleProjectsShowCorrectly()
+    {
+        var stringBuilder = new StringBuilder();
+        var textWriter = new StringWriter(stringBuilder);
+
+        List<AnalyzedProject> analyzedProjects =
+        [
+            new AnalyzedProject("TweetiePie", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie\TweetiePie.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example", new VersionRange(new NuGetVersion(9, 0, 1)), new NuGetVersion(9, 0, 1), false, false, false, false), new NuGetVersion(9, 1, 2)),
+                })
+            }),
+            new AnalyzedProject("TweetiePie.API", @"C:\Coding\codeflow\tweetiepie\src\TweetiePie.API\TweetiePie.API.csproj", new List<AnalyzedTargetFramework>
+            {
+                new AnalyzedTargetFramework(NuGetFramework.Parse("net9.0"), new List<AnalyzedDependency>
+                {
+                    new AnalyzedDependency(new Dependency("Package.Example.Client", new VersionRange(new NuGetVersion(6, 2, 8)), new NuGetVersion(6, 2, 8), false, false, false, false), new NuGetVersion(6, 2, 9))
+                })
+            })
+        ];
+
+        var html = new HtmlFormatter();
+        await html.FormatAsync(analyzedProjects, textWriter);
+
+        const string expectedReport =
+          """
+          <h1>Outdated Packages</h1>
+          <h2>TweetiePie</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example</td>
+          <td>False</td>
+          <td style="text-align: right;">9.0.1</td>
+          <td style="text-align: right;"><span>9.</span><span style="color:orange;font-weight:bold">1.2</span></td>
+          <td style="text-align: right;">Minor</td>
+          </tr>
+          </tbody></table>
+          <h2>TweetiePie.API</h2>
+          <h3>Target:net9.0</h3>
+          <table><thead><tr>
+          <th>Package</th>
+          <th>Transitive</th>
+          <th style="text-align: right;">Current</th>
+          <th style="text-align: right;">Last</th>
+          <th style="text-align: right;">Severity</th>
+          </tr></thead>
+          <tbody>
+          <tr>
+          <td>Package.Example.Client</td>
+          <td>False</td>
+          <td style="text-align: right;">6.2.8</td>
+          <td style="text-align: right;"><span>6.2.</span><span style="color:green;font-weight:bold">9</span></td>
+          <td style="text-align: right;">Patch</td>
+          </tr>
+          </tbody></table>
+
+          """ + _noteString;
+
+        Assert.Equal(expectedReport, stringBuilder.ToString());
+    }
+}


### PR DESCRIPTION
While trying to get this to work in Azure DevOps, I found that the Markdown format doesn't work with the Azure DevOps comments. So I decided to create a simple HTML Formatter to output almost exactly what Markdown does, but as pure HTML.

Things different to the Markdown formatter:
- I use Orange instead of Yellow for Minor severities. This is to make it more visible on light themes. (see difference at the bottom)
- It's unit tested
- Doesn't break when using -utd

Colour change comparison:
![image](https://github.com/user-attachments/assets/0bb0d1ba-7607-4b4c-b95c-f92dd711d7b8)
