### PR TITLE
Fix updating legacy projects using CPM

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -280,9 +280,9 @@ namespace DotNetOutdated
                {
                   RunStatus status = null;
 
-                  if (!project.IsProjectSdkStyle())
+                  if (!project.IsProjectSdkStyle() && !package.IsVersionCentrallyManaged)
                   {
-                     console.WriteLine("Project format not SDK style, removing package before upgrade.");
+                     console.WriteLine("Project format not SDK style or centrally managed, removing package before upgrade.");
                      status = _dotNetPackageService.RemovePackage(project.ProjectFilePath, package.Name);
                   }
 


### PR DESCRIPTION
Updating currently fails for projects using the old project style with central package management, due to an oversight in #538.

Projects using the old project style need to remove the package before updating (due to a long standing NuGet bug), but this is not necessary or possible when using CPM.

This PR adds a check to avoid attempting to remove the reference if the package is centrally managed.