### PR TITLE
chore: update TargetFrameworks to net8 and net9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,8 @@ jobs:
         uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: | 
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
       # The tests should have already been run during the PR workflow, so this is really just a sanity check
       - name: Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework: ['net6.0', 'net7.0', 'net8.0']
+        framework: ['net8.0', 'net9.0']
     timeout-minutes: 30
 
     steps:
@@ -35,9 +35,8 @@ jobs:
       uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: | 
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
     - name: Smoke test
       run: |

--- a/src/DotNetOutdated.Core/DotNetOutdated.Core.csproj
+++ b/src/DotNetOutdated.Core/DotNetOutdated.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageTags>dotnet;outdated;core;lib</PackageTags>
     <Description>The core functionality of DotNet Outdated as a library which allows you to embed it into your own applications</Description>

--- a/src/DotNetOutdated/DotNetOutdated.csproj
+++ b/src/DotNetOutdated/DotNetOutdated.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-outdated</ToolCommandName>

--- a/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
+++ b/test/DotNetOutdated.Tests/DotNetOutdated.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -103,12 +103,7 @@ public static class EndToEndTests
         private static DirectoryInfo CreateTempSubdirectory()
         {
             const string Prefix = "dotnet-bumper-";
-#if NET6_0
-            var tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Prefix + Guid.NewGuid().ToString("N"));
-            return Directory.CreateDirectory(tempPath);
-#else
             return Directory.CreateTempSubdirectory(Prefix);
-#endif
         }
     }
 }


### PR DESCRIPTION
These are the current LTS and STS respectively and should be the targeted frameworks

closes #612