### PR TITLE
[Issue-576]use package source mapping in command

### DIFF
--- a/src/DotNetOutdated.Core/Services/INuGetPackageInfoServiceLogger.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageInfoServiceLogger.cs
@@ -1,0 +1,6 @@
+namespace DotNetOutdated.Core.Services;
+
+public interface INuGetPackageInfoServiceLogger
+{
+    void PackageSourceSkipped(string sourceName, string packageId);
+}

--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -17,6 +17,7 @@ namespace DotNetOutdated.Core.Services
 
     public sealed class NuGetPackageInfoService : INuGetPackageInfoService, IDisposable
     {
+        private readonly INuGetPackageInfoServiceLogger _logger;
         private IEnumerable<PackageSource> _enabledSources;
 
         private PackageSourceMapping _packageSourceMapping;
@@ -25,8 +26,9 @@ namespace DotNetOutdated.Core.Services
 
         private readonly ConcurrentDictionary<string, Lazy<Task<PackageMetadataResource>>> _metadataResourceRequests = new ConcurrentDictionary<string, Lazy<Task<PackageMetadataResource>>>();
 
-        public NuGetPackageInfoService()
+        public NuGetPackageInfoService(INuGetPackageInfoServiceLogger logger)
         {
+            _logger = logger;
             _context = new SourceCacheContext()
             {
                 NoCache = true
@@ -62,9 +64,9 @@ namespace DotNetOutdated.Core.Services
                 if (enabledSource != null && _packageSourceMapping.IsEnabled)
                 {
                     var mappedSources = _packageSourceMapping.GetConfiguredPackageSources(packageId);
-                    if (mappedSources != null && (!mappedSources.Any(s => String.Equals(s, enabledSource.Name, StringComparison.OrdinalIgnoreCase))))
+                    if (mappedSources != null && !mappedSources.Any(s => string.Equals(s, enabledSource.Name, StringComparison.OrdinalIgnoreCase)))
                     {
-                        Console.WriteLine($"package source {enabledSource.Name} skipped by packageSourceMapping, packageId: {packageId}");
+                        _logger.PackageSourceSkipped(enabledSource.Name, packageId);
                         return null;
                     }
                 }

--- a/src/DotNetOutdated/NuGetPackageInfoServiceLogger.cs
+++ b/src/DotNetOutdated/NuGetPackageInfoServiceLogger.cs
@@ -8,6 +8,6 @@ internal sealed class NuGetPackageInfoServiceLogger(IConsole console) : INuGetPa
     public void PackageSourceSkipped(string sourceName, string packageId)
     {
         console.WriteLine(
-            $"package source {sourceName} skipped by packageSourceMapping, packageId: {packageId}");
+            $"Package source {sourceName} skipped by packageSourceMapping, packageId: {packageId}");
     }
 }

--- a/src/DotNetOutdated/NuGetPackageInfoServiceLogger.cs
+++ b/src/DotNetOutdated/NuGetPackageInfoServiceLogger.cs
@@ -1,0 +1,13 @@
+using DotNetOutdated.Core.Services;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace DotNetOutdated;
+
+internal sealed class NuGetPackageInfoServiceLogger(IConsole console) : INuGetPackageInfoServiceLogger
+{
+    public void PackageSourceSkipped(string sourceName, string packageId)
+    {
+        console.WriteLine(
+            $"package source {sourceName} skipped by packageSourceMapping, packageId: {packageId}");
+    }
+}

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -138,6 +138,7 @@ namespace DotNetOutdated
                  .AddSingleton<IDependencyGraphService, DependencyGraphService>()
                  .AddSingleton<IDotNetRestoreService, DotNetRestoreService>()
                  .AddSingleton<IDotNetPackageService, DotNetPackageService>()
+                 .AddSingleton<INuGetPackageInfoServiceLogger>(provider => new NuGetPackageInfoServiceLogger(provider.GetService<IConsole>()))
                  .AddSingleton<INuGetPackageInfoService, NuGetPackageInfoService>()
                  .AddSingleton<INuGetPackageResolutionService, NuGetPackageResolutionService>()
                  .AddSingleton<ICentralPackageVersionManagementService, CentralPackageVersionManagementService>()


### PR DESCRIPTION
This is a fix for issue [Issue-576](https://github.com/dotnet-outdated/dotnet-outdated/issues/576)
It will use package source mapping in the same NuGet config file as NuGet package source.

