### PR TITLE
Use ProcessStartInfo.ArgumentList and Parallel.ForEachAsync

### DIFF
--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -12,16 +12,10 @@ namespace DotNetOutdated.Core.Services
     /// <remarks>
     /// Credit for the stuff happening in here goes to the https://github.com/jaredcnance/dotnet-status project
     /// </remarks>
-    public sealed class DependencyGraphService : IDependencyGraphService
+    public sealed class DependencyGraphService(IDotNetRunner dotNetRunner, IFileSystem fileSystem) : IDependencyGraphService
     {
-        private readonly IDotNetRunner _dotNetRunner;
-        private readonly IFileSystem _fileSystem;
-
-        public DependencyGraphService(IDotNetRunner dotNetRunner, IFileSystem fileSystem)
-        {
-            _dotNetRunner = dotNetRunner;
-            _fileSystem = fileSystem;
-        }
+        private readonly IDotNetRunner _dotNetRunner = dotNetRunner;
+        private readonly IFileSystem _fileSystem = fileSystem;
 
         public async Task<DependencyGraphSpec> GenerateDependencyGraphAsync(string projectPath, string runtime)
         {
@@ -29,13 +23,12 @@ namespace DotNetOutdated.Core.Services
             string[] arguments =
             [
                 "msbuild",
-                $"\"{projectPath}\"",
+                projectPath,
                 "/p:NoWarn=NU1605",
                 "/p:TreatWarningsAsErrors=false",
                 "/t:Restore,GenerateRestoreGraphFile",
-                $"/p:RestoreGraphOutputPath=\"{dgOutput}\"",
-                $"/p:RuntimeIdentifiers=\"{runtime}\""
-
+                $"/p:RestoreGraphOutputPath={dgOutput}",
+                $"/p:RuntimeIdentifiers={runtime}"
             ];
 
             var runStatus = _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments);

--- a/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
@@ -5,16 +5,10 @@ using System.IO.Abstractions;
 
 namespace DotNetOutdated.Core.Services
 {
-    public class DotNetPackageService : IDotNetPackageService
+    public class DotNetPackageService(IDotNetRunner dotNetRunner, IFileSystem fileSystem) : IDotNetPackageService
     {
-        private readonly IDotNetRunner _dotNetRunner;
-        private readonly IFileSystem _fileSystem;
-
-        public DotNetPackageService(IDotNetRunner dotNetRunner, IFileSystem fileSystem)
-        {
-            _dotNetRunner = dotNetRunner;
-            _fileSystem = fileSystem;
-        }
+        private readonly IDotNetRunner _dotNetRunner = dotNetRunner;
+        private readonly IFileSystem _fileSystem = fileSystem;
 
         public RunStatus AddPackage(string projectPath, string packageName, string frameworkName, NuGetVersion version)
         {
@@ -27,7 +21,7 @@ namespace DotNetOutdated.Core.Services
 
             string projectName = _fileSystem.Path.GetFileName(projectPath);
 
-            List<string> arguments = new List<string> { "add", $"\"{projectName}\"", "package", packageName, "-v", version.ToString(), "-f", $"\"{frameworkName}\"" };
+            List<string> arguments = ["add", projectName, "package", packageName, "-v", version.ToString(), "-f", frameworkName];
             if (noRestore)
             {
                 arguments.Add("--no-restore");
@@ -37,13 +31,13 @@ namespace DotNetOutdated.Core.Services
                 arguments.Add("--ignore-failed-sources");
             }
 
-            return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments.ToArray());
+            return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), [.. arguments]);
         }
 
         public RunStatus RemovePackage(string projectPath, string packageName)
         {
            var projectName = _fileSystem.Path.GetFileName(projectPath);
-           var arguments = new[] { "remove", $"\"{projectName}\"", "package", packageName };
+           string[] arguments = ["remove", projectName, "package", packageName];
 
            return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments);
         }

--- a/src/DotNetOutdated.Core/Services/DotNetRestoreService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetRestoreService.cs
@@ -2,20 +2,14 @@
 
 namespace DotNetOutdated.Core.Services
 {
-    public class DotNetRestoreService : IDotNetRestoreService
+    public class DotNetRestoreService(IDotNetRunner dotNetRunner, IFileSystem fileSystem) : IDotNetRestoreService
     {
-        private readonly IDotNetRunner _dotNetRunner;
-        private readonly IFileSystem _fileSystem;
-
-        public DotNetRestoreService(IDotNetRunner dotNetRunner, IFileSystem fileSystem)
-        {
-            _dotNetRunner = dotNetRunner;
-            _fileSystem = fileSystem;
-        }
+        private readonly IDotNetRunner _dotNetRunner = dotNetRunner;
+        private readonly IFileSystem _fileSystem = fileSystem;
 
         public RunStatus Restore(string projectPath)
         {
-            string[] arguments = new[] { "restore", $"\"{projectPath}\"" };
+            string[] arguments = ["restore", projectPath];
 
             return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments);
         }

--- a/src/DotNetOutdated.Core/Services/DotNetRunner.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetRunner.cs
@@ -16,7 +16,7 @@ namespace DotNetOutdated.Core.Services
     {
         public RunStatus Run(string workingDirectory, string[] arguments)
         {
-            var psi = new ProcessStartInfo("dotnet", string.Join(" ", arguments))
+            var psi = new ProcessStartInfo("dotnet", arguments)
             {
                 WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
@@ -37,7 +37,7 @@ namespace DotNetOutdated.Core.Services
                 var outputTask = ConsumeStreamReaderAsync(p.StandardOutput, timeSinceLastOutput, output);
                 var errorTask = ConsumeStreamReaderAsync(p.StandardError, timeSinceLastOutput, errors);
                 bool processExited = false;
-                const int Timeout = 20000;
+                const int Timeout = 20_000;
 
                 while (true) {
                     if (p.HasExited) {

--- a/src/DotNetOutdated/DotNetOutdated.csproj
+++ b/src/DotNetOutdated/DotNetOutdated.csproj
@@ -17,7 +17,6 @@
     <PackageVersion>$(VersionSuffix)</PackageVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet-outdated/dotnet-outdated.git</RepositoryUrl>
-    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
@@ -47,7 +47,7 @@ namespace DotNetOutdated.Tests
             Assert.NotNull(dependencyGraph);
             Assert.Equal(3, dependencyGraph.Projects.Count);
 
-            dotNetRunner.Received().Run(XFS.Path(@"c:\"), Arg.Is<string[]>(a => a[0] == "msbuild" && a[1] == '\"' + _path + '\"'));
+            dotNetRunner.Received().Run(XFS.Path(@"c:\"), Arg.Is<string[]>(a => a[0] == "msbuild" && a[1] == _path));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace DotNetOutdated.Tests
             Assert.NotNull(dependencyGraph);
             Assert.Empty(dependencyGraph.Projects);
 
-            dotNetRunner.Received().Run(_path, Arg.Is<string[]>(a => a[0] == "msbuild" && a[1] == '\"' + _solutionPath + '\"' && a[4] == "/t:Restore,GenerateRestoreGraphFile"));
+            dotNetRunner.Received().Run(_path, Arg.Is<string[]>(a => a[0] == "msbuild" && a[1] == _solutionPath && a[4] == "/t:Restore,GenerateRestoreGraphFile"));
         }
     }
 }


### PR DESCRIPTION
While working on #640 I spotted a few things that could be improved:

- Use `ProcessStartInfo.ArgumentList` to start `dotnet` to avoid needing to quote/concatenate arguments into a single string.
- Use `Parallel.ForEachAsync()` instead of manually managing tasks.
- Remove duplicate MSBuild property.

Also applies some IDE code refactoring suggestions in touched files such as using collection expressions and using primary constructors.
