### PR TITLE
Fix version detection of transitive dependencies

### DIFF
--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -92,7 +92,7 @@ namespace DotNetOutdated.Core.Services
             {
                 foreach (var packageDependency in parentLibrary.Dependencies)
                 {
-                    var childLibrary = target.Libraries.FirstOrDefault(library => library.Name == packageDependency.Id);
+                    var childLibrary = target.Libraries.FirstOrDefault(library => string.Equals(library.Name, packageDependency.Id, StringComparison.OrdinalIgnoreCase));
 
                     // Only add library and process child dependencies if we have not come across this dependency before
                     if (!targetFramework.Dependencies.ContainsKey(packageDependency.Id))


### PR DESCRIPTION
When transitive dependencies have alternate casing used in their definitions, then these dependencies are resolved incorrectly. Version range of the dependency is not discovered and execution fails with error message: `"Errors occurred while analyzing dependencies for some of your projects. Are you sure you can connect to all your configured NuGet servers?"` (because `UpgradeServerity` of the package is `Unknown`).

For example package [FluentValidation.DependencyInjectionExtensions](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/12.0.0#dependencies-body-tab) which has dependency on package *Microsoft.Extensions.Dependencyinjection.Abstractions* (pay attention to lowercase "i" at the start of "injection").

Fixed by using case-insensitive comparing of package names (as already done in the case of explicit dependencies).