### PR TITLE
Fix: Parameter --maximum-version ignores exact version references

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -524,7 +524,7 @@ namespace DotNetOutdated
          NuGetVersion latestVersion = null;
 
         if (maximumVersion is not null &&
-            (versionRange.MaxVersion is null || maximumVersion > versionRange.MaxVersion))
+            (versionRange.MaxVersion is null || maximumVersion < versionRange.MaxVersion))
         {
             // Patch the version range to include the user-specified maximum
             versionRange = new(

--- a/test-projects/max-version/Project.csproj
+++ b/test-projects/max-version/Project.csproj
@@ -4,5 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="[6.0.0]" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[9.0.0]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #670 - Parameter `--maximum-version` ignores exact version references