### PR TITLE
Set RollForward=Major

### DIFF
--- a/src/DotNetOutdated/DotNetOutdated.csproj
+++ b/src/DotNetOutdated/DotNetOutdated.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-outdated</ToolCommandName>
+    <RollForward>Major</RollForward>
     <AssemblyName>dotnet-outdated</AssemblyName>
     <Authors>dotnet-outdated Team &amp; Contributors</Authors>
     <Copyright>Copyright (c) Jerrie Pelser</Copyright>


### PR DESCRIPTION
This allows the dotnet outdated tool to run even if only .NET 10 is installed on the machine.

cc @joperezr @radical