### PR TITLE
Allow --maximum-version to be specified multiple times against specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Options:
                                                         Default value is: Warning.
   -rt|--runtime <RUNTIME>                               Specifies an optional runtime identifier to be used during the restore target when projects are analyzed.
                                                         More information available on https://learn.microsoft.com/dotnet/core/rid-catalog.
-  -mv|--maximum-version <MAX_VERSION>                   The inclusive maximum package version to upgrade to. For example, a value of '8.0' would upgrade System.Text.Json 6.0.0 to the latest patch version of 8.0.x
+  -mv|--maximum-version <MAX_VERSION>                   The inclusive maximum package version to upgrade to, can be specified multiple times for different packages. For example, a value of 'System.Text.Json:8' would upgrade System.Text.Json 6.0.0 to the latest version of 8.x. Or a value of 'Microsoft.Extensions:8.1' would upgrade all packages starting with 'Microsoft.Extensions' to a maximum of 8.1.x. If no package name is specified, such as '8' or '8.0' then the maximum value will apply to all packages (expect for those with specific maximum versions configured)
 ```
 
 ![Screenshot of dotnet-outdated](screenshot.png)

--- a/test-projects/max-versions/Project.csproj
+++ b/test-projects/max-versions/Project.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+  </ItemGroup>
+</Project>

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -62,14 +62,20 @@ public static class EndToEndTests
         Assert.Equal(0, actual);
     }
 
-    [Fact]
-    public static void Can_Upgrade_Project_With_Maximum_Version()
+    [Theory]
+    [InlineData("8")]
+    [InlineData("8.0")]
+    [InlineData("System.Text.Json:8")]
+    [InlineData("System.Text.Json:8.0")]
+    [InlineData("System:8")]
+    [InlineData("System:8.0")]
+    public static void Can_Upgrade_Project_With_Maximum_Version(string maximumVersion)
     {
         using var directory = TestSetup("max-version");
 
         var outputPath = Path.Combine(directory.Path, "output.json");
 
-        var actual = Program.Main([directory.Path, "--maximum-version:8.0", "--output", outputPath, "--output-format:json"]);
+        var actual = Program.Main([directory.Path, $"--maximum-version:{maximumVersion}", "--output", outputPath, "--output-format:json"]);
         Assert.Equal(0, actual);
 
         using var output = JsonDocument.Parse(File.ReadAllText(outputPath));
@@ -86,6 +92,46 @@ public static class EndToEndTests
                     Assert.Equal(8, latestVersion.Major);
                     Assert.Equal(0, latestVersion.Minor);
                     Assert.NotEqual(0, latestVersion.Build);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public static void Can_Upgrade_Multiple_Projects_With_Differing_Maximum_Versions()
+    {
+        using var directory = TestSetup("max-versions");
+
+        var outputPath = Path.Combine(directory.Path, "output.json");
+
+        var actual = Program.Main([directory.Path, $"--maximum-version:System.Text.Json:8.0", "--maximum-version:Newtonsoft.Json:12", "--output", outputPath, "--output-format:json"]);
+        Assert.Equal(0, actual);
+
+        using var output = JsonDocument.Parse(File.ReadAllText(outputPath));
+
+        foreach (var project in output.RootElement.GetProperty("Projects").EnumerateArray())
+        {
+            foreach (var tfm in project.GetProperty("TargetFrameworks").EnumerateArray())
+            {
+                foreach (var dependency in tfm.GetProperty("Dependencies").EnumerateArray())
+                {
+                    var latestVersionString = dependency.GetProperty("LatestVersion").GetString();
+                    var name = dependency.GetProperty("Name").GetString();
+
+                    Assert.True(Version.TryParse(latestVersionString, out var latestVersion));
+
+                    if (name == "Newtonsoft.Json")
+                    {
+                        Assert.Equal(12, latestVersion.Major);
+                        Assert.Equal(0, latestVersion.Minor);
+                        Assert.NotEqual(0, latestVersion.Build);
+                    }
+                    else
+                    {
+                        Assert.Equal(8, latestVersion.Major);
+                        Assert.Equal(0, latestVersion.Minor);
+                        Assert.NotEqual(0, latestVersion.Build);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This feature is intended to support scenarios where users want to avoid upgrading specific packages beyond a known max version. Example scenarios for this could be:

- a package has implemented a license change in newer versions (ie it's gone commercial)
- a package has breaking changes and would be too hard to upgrade
- a package has known vulnerabilities that we want to avoid

To provide for this the `--maximum-version` parameter can now specify a package, or package group, in order to target specific packages; we can also now use the `--maximum-version` parameter multiple times to set different max versions for different packages. Examples being:

- `--maximum-version System.Text.Json:8.0` - set the max version for System.Text.Json to 8.0.x
- `--maximum-version Microsoft.Extensions:7` - set the max version all packages matching "Microsoft.Extensions" to 7.x.x
- `--maximum-version System.Text.Json:8.0 --maximum-version Microsoft.Extensions:7` - both of the above at once

The previous usage of the `--maximum-version` parameter still applies so `--maximum-version 8.0` would apply to all packages.

If previous usage and new usage are used together, eg: `--maximum-version 8.0 --maximum-version System.Text.Json:7`, then the max version of 8.0.x applies to all packages _except_ for System.Text.Json

The `--maximum-version` parameter now also allows you to specify just the major version - previously had to be major.minor.