### PR TITLE
Fix NullReferenceException when GetLockFile returns null (#740)

### DIFF
--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -16,12 +16,19 @@ namespace DotNetOutdated.Core.Services
         private readonly IDependencyGraphService _dependencyGraphService;
         private readonly IDotNetRestoreService _dotNetRestoreService;
         private readonly IFileSystem _fileSystem;
+        private readonly ILogger _logger;
 
         public ProjectAnalysisService(IDependencyGraphService dependencyGraphService, IDotNetRestoreService dotNetRestoreService, IFileSystem fileSystem)
+            : this(dependencyGraphService, dotNetRestoreService, fileSystem, NullLogger.Instance)
+        {
+        }
+
+        public ProjectAnalysisService(IDependencyGraphService dependencyGraphService, IDotNetRestoreService dotNetRestoreService, IFileSystem fileSystem, ILogger logger)
         {
             _dependencyGraphService = dependencyGraphService;
             _dotNetRestoreService = dotNetRestoreService;
             _fileSystem = fileSystem;
+            _logger = logger;
         }
 
         public async Task<List<Project>> AnalyzeProjectAsync(string projectPath, bool runRestore, bool includeTransitiveDependencies, int transitiveDepth,  string runtime)
@@ -41,7 +48,9 @@ namespace DotNetOutdated.Core.Services
 
                 // Load the lock file
                 string lockFilePath = _fileSystem.Path.Combine(packageSpec.RestoreMetadata.OutputPath, "project.assets.json");
-                var lockFile = LockFileUtilities.GetLockFile(lockFilePath, NullLogger.Instance);
+                var lockFile = LockFileUtilities.GetLockFile(lockFilePath, _logger);
+                if (lockFile == null)
+                    throw new InvalidOperationException($"Could not load lock file '{lockFilePath}' for project '{packageSpec.FilePath}'. The file may be missing, unreadable, or in an unsupported format. Try running 'dotnet restore' on the project.");
 
                 // Create a project
                 var project = new Project(packageSpec.Name, packageSpec.FilePath, packageSpec.RestoreMetadata.Sources.Select(s => s.SourceUri).ToList(), packageSpec.Version);

--- a/src/DotNetOutdated/McpCommand.cs
+++ b/src/DotNetOutdated/McpCommand.cs
@@ -2,6 +2,7 @@ using DotNetOutdated.Core.Services;
 using DotNetOutdated.Services;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
+using NuGet.Common;
 using System;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
@@ -18,6 +19,7 @@ namespace DotNetOutdated
                  .AddSingleton<IConsole>(McpConsole.Singleton)
                  .AddSingleton<IReporter>(provider => new ConsoleReporter(provider.GetService<IConsole>()))
                  .AddSingleton<IFileSystem, FileSystem>()
+                 .AddSingleton<ILogger>(provider => new ConsoleLogger(provider.GetService<IConsole>(), LogLevel.Warning))
                  .AddSingleton<IProjectDiscoveryService, ProjectDiscoveryService>()
                  .AddSingleton<IProjectAnalysisService, ProjectAnalysisService>()
                  .AddSingleton<IDotNetRunner, DotNetRunner>()

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -150,6 +150,7 @@ namespace DotNetOutdated
                  .AddSingleton(PhysicalConsole.Singleton)
                  .AddSingleton<IReporter>(provider => new ConsoleReporter(provider.GetService<IConsole>()))
                  .AddSingleton<IFileSystem, FileSystem>()
+                 .AddSingleton<ILogger>(provider => new ConsoleLogger(provider.GetService<IConsole>(), LogLevel.Warning))
                  .AddSingleton<IProjectDiscoveryService, ProjectDiscoveryService>()
                  .AddSingleton<IProjectAnalysisService, ProjectAnalysisService>()
                  .AddSingleton<DotNetRunnerOptions>()


### PR DESCRIPTION
Fixes #740.

 `ProjectAnalysisService.AnalyzeProjectAsync` was passing
 `NullLogger.Instance` to `LockFileUtilities.GetLockFile` and then
 dereferencing the result without a null check, so any failure to
 load `project.assets.json` surfaced as an opaque
 `NullReferenceException` and the underlying NuGet diagnostic
 (when one was emitted) was silently discarded.

  Changes:
  - Pass an `ILogger` to `GetLockFile` so reader diagnostics reach the user.
  - Null-check the result and throw a contextual `InvalidOperationException`
  - Add a logger-aware constructor overload on `ProjectAnalysisService`;
    the existing 3-arg constructor is preserved (delegates with
    `NullLogger.Instance`) so the published `DotNetOutdatedTool.Core`
    library stays binary-compatible.
  - Register `ILogger` (as `ConsoleLogger` at `LogLevel.Warning`) in
    the CLI and MCP composition roots; MS.DI's greedy constructor
    selection then prefers the new overload. This is not ideal, but I 
   could not find a better balance between the fix being "correct" and 
   too noisy.
