### PR TITLE
Fix CI: pass short framework name to dotnet add package on upgrade

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -305,7 +305,7 @@ namespace DotNetOutdated
                   }
 
                   if (status is null || status.IsSuccess)
-                     status = _dotNetPackageService.AddPackage(project.ProjectFilePath, package.Name, project.Framework.ToString(), package.LatestVersion, NoRestore, IgnoreFailedSources);
+                     status = _dotNetPackageService.AddPackage(project.ProjectFilePath, package.Name, project.Framework.GetShortFolderName(), package.LatestVersion, NoRestore, IgnoreFailedSources);
 
                   if (status.IsSuccess)
                   {


### PR DESCRIPTION
The `--upgrade` path passed `project.Framework.ToString()` (the long-form moniker, e.g. `.NETStandard,Version=v2.0`) as the `-f` argument to `dotnet add package`, but newer .NET SDKs reject that form with "Package is incompatible with 'user specified' frameworks", causing every upgrade to fail. This broke the variable-preservation end-to-end tests on every PR in CI. The fix uses `NuGetFramework.GetShortFolderName()` (e.g. `netstandard2.0`), which is the form the `-f` flag expects. All 172 tests now pass locally (1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)