### PR TITLE
Add .NET file-based app support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,4 +81,4 @@ jobs:
         exit 0
 
     - name: File-based app tests
-      run: dotnet test --configuration Release --framework net9.0 --filter "FullyQualifiedName~File_Based_App"
+      run: dotnet test --configuration Release --framework net9.0 --filter "FullyQualifiedName~FileBasedApp|FullyQualifiedName~File_Based_App"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,32 @@ jobs:
         dotnet-version: | 
             8.0.x
             9.0.x
-            10.0.300
 
     - name: Smoke test
       run: |
         dotnet run --configuration Release --framework ${{ matrix.framework }} --project src/DotNetOutdated test-projects/development-dependencies
+
+    - name: Tests
+      run: dotnet test --configuration Release --framework ${{ matrix.framework }}
+
+  file-based-app:
+    name: File-based app tests with .NET SDK 10.0.300 on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5.2.0
+      with:
+        dotnet-version: |
+            9.0.x
+            10.0.300
 
     - name: File-based app smoke test
       shell: pwsh
@@ -50,7 +71,7 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $false
         }
 
-        & dotnet run --configuration Release --framework ${{ matrix.framework }} --project src/DotNetOutdated -- test-projects/file-based-app/app.cs --fail-on-updates
+        & dotnet run --configuration Release --framework net9.0 --project src/DotNetOutdated -- test-projects/file-based-app/app.cs --fail-on-updates
         $exitCode = $LASTEXITCODE
 
         if ($exitCode -ne 2) {
@@ -59,5 +80,5 @@ jobs:
 
         exit 0
 
-    - name: Tests
-      run: dotnet test --configuration Release --framework ${{ matrix.framework }}
+    - name: File-based app tests
+      run: dotnet test --configuration Release --framework net9.0 --filter "FullyQualifiedName~File_Based_App"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,27 @@ jobs:
         dotnet-version: | 
             8.0.x
             9.0.x
+            10.0.300
 
     - name: Smoke test
       run: |
         dotnet run --configuration Release --framework ${{ matrix.framework }} --project src/DotNetOutdated test-projects/development-dependencies
+
+    - name: File-based app smoke test
+      shell: pwsh
+      run: |
+        if (Get-Variable PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+          $PSNativeCommandUseErrorActionPreference = $false
+        }
+
+        & dotnet run --configuration Release --framework ${{ matrix.framework }} --project src/DotNetOutdated -- test-projects/file-based-app/app.cs --fail-on-updates
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -ne 2) {
+          throw "Expected file-based app smoke test to exit with 2 because outdated dependencies were found, but got $exitCode."
+        }
+
+        exit 0
 
     - name: Tests
       run: dotnet test --configuration Release --framework ${{ matrix.framework }}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ dotnet tool update --global dotnet-outdated-tool
 Usage: dotnet outdated [options] <Path>
 
 Arguments:
-  Path                                                  The path to a .sln, .slnx, .slnf, .csproj or .fsproj file, or to a directory containing a .NET Core solution/project. If none is specified, the current directory will be used.
+  Path                                                  The path to a .sln, .slnx, .slnf, .csproj, .fsproj or .cs file-based app, or to a directory containing a .NET Core solution/project. If none is specified, the current directory will be used.
 
 Options:
   --version                                             Show version information.
@@ -87,6 +87,7 @@ Options:
                                                         Default value is: 0.
   -n|--no-restore                                       Add the reference without performing restore preview and compatibility check.
   -r|--recursive                                        Recursively search for all projects within the provided directory.
+  -fba|--include-file-based-apps                        Include loose file-based apps when recursively searching a directory.
   -ifs|--ignore-failed-sources                          Treat package source failures as warnings.
   -utd|--include-up-to-date                             Include all dependencies in the report even the ones not outdated.
   -prl|--pre-release-label <PRERELEASE_LABEL>           Specifies an optional label to restrict matches to when looking for pre-release versions of packages. For example, a label of 'rc.1' would only match
@@ -107,7 +108,9 @@ You can run **dotnet-outdated** without specifying the `Path` argument. In this 
 
 You can also pass a directory in the `Path` argument, in which case the same logic described above will be used, but in the directory specified.
 
-Lastly, you can specify the path to a solution (`.sln` or `.slnx`) or project (`.csproj` or `.fsproj`) which **dotnet-outdated** must analyze.
+Lastly, you can specify the path to a solution (`.sln` or `.slnx`), project (`.csproj` or `.fsproj`), or .NET file-based app (`.cs`) which **dotnet-outdated** must analyze. File-based apps require .NET SDK 10.0.300 or later.
+
+When `--recursive --include-file-based-apps` is used, **dotnet-outdated** also discovers loose `.cs` file-based apps that start with a shebang (`#!`). `.cs` files under a `.csproj` directory tree are ignored during recursive file-based app discovery.
 
 ## Upgrading packages
 
@@ -239,7 +242,7 @@ Add the following to your `.vscode/mcp.json`:
 
 ### Why are unrelated changes made to .csproj files when running with `-u`?
 
-`dotnet-outdated` does not make any changes to .csproj files directly. Instead, it runs `dotnet add package` to update packages, so that command is responsible for all changes made. To track issues related to this command, head over to the [.NET CLI repo](https://github.com/dotnet/cli)
+`dotnet-outdated` does not make changes to .csproj files directly. Instead, it runs `dotnet add package` to update packages, so that command is responsible for those changes. For file-based apps that use variable-backed `#:package` directives, `dotnet-outdated` updates the referenced `#:property` value directly so the variable reference is preserved. To track issues related to the .NET CLI command, head over to the [.NET CLI repo](https://github.com/dotnet/cli)
 
 ### Why I am getting an error about required library hostfxr.dll/libhostfxr.so/libhostfxr.dylib not found?
 

--- a/src/DotNetOutdated.Core/ProjectPathExtensions.cs
+++ b/src/DotNetOutdated.Core/ProjectPathExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+
+namespace DotNetOutdated.Core
+{
+    public static class ProjectPathExtensions
+    {
+        public static bool IsCSharpFile(this string path)
+        {
+            return string.Equals(Path.GetExtension(path), ".cs", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsCSharpProjectFile(this string path)
+        {
+            return string.Equals(Path.GetExtension(path), ".csproj", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsProjectFile(this string path)
+        {
+            var extension = Path.GetExtension(path);
+            return string.Equals(extension, ".csproj", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(extension, ".fsproj", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsSolutionFile(this string path)
+        {
+            var extension = Path.GetExtension(path);
+            return string.Equals(extension, ".sln", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(extension, ".slnx", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(extension, ".slnf", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.Designer.cs
+++ b/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.Designer.cs
@@ -78,7 +78,7 @@ namespace DotNetOutdated.Core.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The directory &apos;{0}&apos; does not contain any solutions or projects..
+        ///   Looks up a localized string similar to The directory &apos;{0}&apos; does not contain any solutions, projects, or file-based apps..
         /// </summary>
         internal static string DirectoryDoesNotContainSolutionsOrProjects {
             get {
@@ -96,7 +96,7 @@ namespace DotNetOutdated.Core.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file &apos;{0}&apos; is not a valid solution or project..
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; is not a valid solution, project, or file-based app..
         /// </summary>
         internal static string FileNotAValidSolutionOrProject {
             get {

--- a/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.resx
+++ b/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.resx
@@ -124,12 +124,12 @@
     <value>Specify which solution file to use because the directory '{0}' contains more than one.</value>
   </data>
   <data name="DirectoryDoesNotContainSolutionsOrProjects" xml:space="preserve">
-    <value>The directory '{0}' does not contain any solutions or projects.</value>
+    <value>The directory '{0}' does not contain any solutions, projects, or file-based apps.</value>
   </data>
   <data name="DirectoryOrFileDoesNotExist" xml:space="preserve">
     <value>The directory or file '{0}' does not exist.</value>
   </data>
   <data name="FileNotAValidSolutionOrProject" xml:space="preserve">
-    <value>The file '{0}' is not a valid solution or project.</value>
+    <value>The file '{0}' is not a valid solution, project, or file-based app.</value>
   </data>
 </root>

--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -1,4 +1,5 @@
-﻿using DotNetOutdated.Core.Exceptions;
+﻿using DotNetOutdated.Core;
+using DotNetOutdated.Core.Exceptions;
 using NuGet.ProjectModel;
 using System;
 using System.Collections.Generic;
@@ -21,6 +22,27 @@ namespace DotNetOutdated.Core.Services
         public async Task<DependencyGraphSpec> GenerateDependencyGraphAsync(string projectPath, string runtime)
         {
             var dgOutput = _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), _fileSystem.Path.GetRandomFileName());
+            var projectDirectory = _fileSystem.Path.GetDirectoryName(projectPath);
+            var runStatus = projectPath.IsCSharpFile()
+                ? GenerateFileBasedAppDependencyGraph(projectPath, projectDirectory, runtime, dgOutput)
+                : GenerateProjectDependencyGraph(projectPath, projectDirectory, runtime, dgOutput);
+
+            if (runStatus.IsSuccess)
+            {
+                var dependencyGraphText = await _fileSystem.File.ReadAllTextAsync(dgOutput).ConfigureAwait(false);
+                return new ExtendedDependencyGraphSpec(dependencyGraphText);
+            }
+
+            var expectedProjectType = projectPath.IsCSharpFile()
+                ? "a valid .NET file-based app? File-based app support requires .NET SDK 10.0.300 or later"
+                : "a valid .NET Core or .NET Standard project type?";
+
+            throw new CommandValidationException($"Unable to process the project `{projectPath}`. Are you sure this is {expectedProjectType}" +
+                                                $"{Environment.NewLine}{Environment.NewLine}Here is the full error message returned from the Microsoft Build Engine:{Environment.NewLine}{Environment.NewLine}{runStatus.Output} - {runStatus.Errors} - exit code: {runStatus.ExitCode}");
+        }
+
+        private RunStatus GenerateProjectDependencyGraph(string projectPath, string projectDirectory, string runtime, string dgOutput)
+        {
             List<string> arguments =
             [
                 "msbuild",
@@ -36,16 +58,45 @@ namespace DotNetOutdated.Core.Services
                 arguments.Add($"/p:RuntimeIdentifiers={runtime}");
             }
 
-            var runStatus = _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments.ToArray());
+            return _dotNetRunner.Run(projectDirectory, arguments.ToArray());
+        }
 
-            if (runStatus.IsSuccess)
+        private RunStatus GenerateFileBasedAppDependencyGraph(string appPath, string projectDirectory, string runtime, string dgOutput)
+        {
+            List<string> restoreArguments =
+            [
+                "restore",
+                appPath
+            ];
+
+            if (!string.IsNullOrEmpty(runtime))
             {
-                var dependencyGraphText = await _fileSystem.File.ReadAllTextAsync(dgOutput).ConfigureAwait(false);
-                return new ExtendedDependencyGraphSpec(dependencyGraphText);
+                restoreArguments.Add($"/p:RuntimeIdentifiers={runtime}");
             }
 
-            throw new CommandValidationException($"Unable to process the project `{projectPath}. Are you sure this is a valid .NET Core or .NET Standard project type?" +
-                                                $"{Environment.NewLine}{Environment.NewLine}Here is the full error message returned from the Microsoft Build Engine:{Environment.NewLine}{Environment.NewLine}{runStatus.Output} - {runStatus.Errors} - exit code: {runStatus.ExitCode}");
+            var restoreStatus = _dotNetRunner.Run(projectDirectory, restoreArguments.ToArray());
+            if (!restoreStatus.IsSuccess)
+            {
+                return restoreStatus;
+            }
+
+            List<string> buildArguments =
+            [
+                "build",
+                appPath,
+                "--no-restore",
+                "/p:NoWarn=NU1605",
+                "/p:TreatWarningsAsErrors=false",
+                "/t:GenerateRestoreGraphFile",
+                $"/p:RestoreGraphOutputPath={dgOutput}"
+            ];
+
+            if (!string.IsNullOrEmpty(runtime))
+            {
+                buildArguments.Add($"/p:RuntimeIdentifiers={runtime}");
+            }
+
+            return _dotNetRunner.Run(projectDirectory, buildArguments.ToArray());
         }
     }
 }

--- a/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
@@ -26,6 +26,14 @@ namespace DotNetOutdated.Core.Services
             var variables = _variableTrackingService.DiscoverPackageVariables(projectPath);
             variables.TryGetValue(packageName, out PackageVariableInfo variableInfo);
 
+            if (variableInfo?.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType)
+            {
+                _variableTrackingService.UpdatePackageVariable(variableInfo, version);
+                return noRestore
+                    ? new RunStatus(string.Empty, string.Empty, 0)
+                    : RestoreProject(projectPath, ignoreFailedSources);
+            }
+
             // When --no-restore is used, `dotnet add package` has an upstream bug where it writes
             // version info to .csproj instead of Directory.Packages.props for CPM projects.
             // See: https://github.com/NuGet/Home/issues/12552
@@ -75,6 +83,18 @@ namespace DotNetOutdated.Core.Services
             string[] arguments = ["remove", projectName, "package", packageName];
 
             return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), arguments);
+        }
+
+        private RunStatus RestoreProject(string projectPath, bool ignoreFailedSources)
+        {
+            var projectName = _fileSystem.Path.GetFileName(projectPath);
+            List<string> arguments = ["restore", projectName];
+            if (ignoreFailedSources)
+            {
+                arguments.Add("--ignore-failed-sources");
+            }
+
+            return _dotNetRunner.Run(_fileSystem.Path.GetDirectoryName(projectPath), [.. arguments]);
         }
 
         private bool TryUpdateCentralPackageVersion(string projectPath, string packageName, NuGetVersion version)

--- a/src/DotNetOutdated.Core/Services/IProjectDiscoveryService.cs
+++ b/src/DotNetOutdated.Core/Services/IProjectDiscoveryService.cs
@@ -4,6 +4,6 @@ namespace DotNetOutdated.Core.Services
 {
     public interface IProjectDiscoveryService
     {
-        IList<string> DiscoverProjects(string path, bool recursive = false);
+        IList<string> DiscoverProjects(string path, bool recursive = false, bool includeFileBasedApps = false);
     }
 }

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -1,4 +1,5 @@
-﻿using DotNetOutdated.Core.Models;
+﻿using DotNetOutdated.Core;
+using DotNetOutdated.Core.Models;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -37,23 +38,28 @@ namespace DotNetOutdated.Core.Services
             if (dependencyGraph == null)
                 return null;
 
+            var isFileBasedApp = projectPath.IsCSharpFile();
+            var projectFilePath = isFileBasedApp ? _fileSystem.Path.GetFullPath(projectPath) : null;
             var projects = new List<Project>();
             foreach (var packageSpec in dependencyGraph.Projects.Where(p => p.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference))
             {
+                var analyzedProjectPath = isFileBasedApp ? projectFilePath : packageSpec.FilePath;
+
                 // Restore the packages
                 if (runRestore)
                 {
-                    _dotNetRestoreService.Restore(packageSpec.FilePath);
+                    _dotNetRestoreService.Restore(analyzedProjectPath);
                 }
 
                 // Load the lock file
                 string lockFilePath = _fileSystem.Path.Combine(packageSpec.RestoreMetadata.OutputPath, "project.assets.json");
                 var lockFile = LockFileUtilities.GetLockFile(lockFilePath, _logger);
                 if (lockFile == null)
-                    throw new InvalidOperationException($"Could not load lock file '{lockFilePath}' for project '{packageSpec.FilePath}'. The file may be missing, unreadable, or in an unsupported format. Try running 'dotnet restore' on the project.");
+                    throw new InvalidOperationException($"Could not load lock file '{lockFilePath}' for project '{analyzedProjectPath}'. The file may be missing, unreadable, or in an unsupported format. Try running 'dotnet restore' on the project.");
 
                 // Create a project
-                var project = new Project(packageSpec.Name, packageSpec.FilePath, packageSpec.RestoreMetadata.Sources.Select(s => s.SourceUri).ToList(), packageSpec.Version);
+                var projectName = isFileBasedApp ? _fileSystem.Path.GetFileName(projectPath) : packageSpec.Name;
+                var project = new Project(projectName, analyzedProjectPath, packageSpec.RestoreMetadata.Sources.Select(s => s.SourceUri).ToList(), packageSpec.Version);
                 projects.Add(project);
 
                 // Get the target frameworks with their dependencies

--- a/src/DotNetOutdated.Core/Services/ProjectDiscoveryService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectDiscoveryService.cs
@@ -1,4 +1,5 @@
-﻿using DotNetOutdated.Core.Exceptions;
+﻿using DotNetOutdated.Core;
+using DotNetOutdated.Core.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -17,7 +18,7 @@ namespace DotNetOutdated.Core.Services
             _fileSystem = fileSystem;
         }
 
-        public IList<string> DiscoverProjects(string path, bool recursive = false)
+        public IList<string> DiscoverProjects(string path, bool recursive = false, bool includeFileBasedApps = false)
         {
             if (!(_fileSystem.File.Exists(path) || _fileSystem.Directory.Exists(path)))
                 throw new CommandValidationException(string.Format(CultureInfo.InvariantCulture, Resources.ValidationErrorMessages.DirectoryOrFileDoesNotExist, path));
@@ -30,8 +31,20 @@ namespace DotNetOutdated.Core.Services
                 // If we are in recursive mode, find all individual projects recursively
                 if (recursive)
                 {
-                    var recursiveProjectFiles = _fileSystem.Directory.GetFiles(path, "*.csproj", SearchOption.AllDirectories)
-                        .Concat(_fileSystem.Directory.GetFiles(path, "*.fsproj", SearchOption.AllDirectories)).ToArray();
+                    string[] recursiveProjectFiles;
+                    if (includeFileBasedApps)
+                    {
+                        var recursiveDiscoveryResult = DiscoverRecursiveProjectFiles(path, isInProjectCone: false);
+                        recursiveProjectFiles = recursiveDiscoveryResult.ProjectFiles
+                            .Concat(recursiveDiscoveryResult.FileBasedApps)
+                            .ToArray();
+                    }
+                    else
+                    {
+                        recursiveProjectFiles = _fileSystem.Directory.GetFiles(path, "*.csproj", SearchOption.AllDirectories)
+                            .Concat(_fileSystem.Directory.GetFiles(path, "*.fsproj", SearchOption.AllDirectories))
+                            .ToArray();
+                    }
 
                     if (recursiveProjectFiles.Length > 0)
                         return recursiveProjectFiles;
@@ -54,7 +67,7 @@ namespace DotNetOutdated.Core.Services
 
                 if (solutionFiles.Length > 1)
                     throw new CommandValidationException(string.Format(CultureInfo.InvariantCulture, Resources.ValidationErrorMessages.DirectoryContainsMultipleSolutions, path));
-                
+
                 // We did not find any solutions, so try and find individual projects
                 var projectFiles = _fileSystem.Directory.GetFiles(path, "*.csproj").Concat(_fileSystem.Directory.GetFiles(path, "*.fsproj")).ToArray();
                 if (projectFiles.Length == 1)
@@ -68,17 +81,77 @@ namespace DotNetOutdated.Core.Services
             }
 
             // If a solution file or project file was passed, just return that
-            if ((string.Equals(_fileSystem.Path.GetExtension(path), ".sln", StringComparison.OrdinalIgnoreCase)) ||
-                (string.Equals(_fileSystem.Path.GetExtension(path), ".csproj", StringComparison.OrdinalIgnoreCase)) ||
-                (string.Equals(_fileSystem.Path.GetExtension(path), ".fsproj", StringComparison.OrdinalIgnoreCase)) ||
-                (string.Equals(_fileSystem.Path.GetExtension(path), ".slnx", StringComparison.OrdinalIgnoreCase)) ||
-                (string.Equals(_fileSystem.Path.GetExtension(path), ".slnf", StringComparison.OrdinalIgnoreCase)))
+            if (path.IsSolutionFile() || path.IsProjectFile() || path.IsCSharpFile())
             {
                 return new[] { _fileSystem.Path.GetFullPath(path) };
             }
 
             // At this point, we know the file passed in is not a valid project or solution
             throw new CommandValidationException(string.Format(CultureInfo.InvariantCulture, Resources.ValidationErrorMessages.FileNotAValidSolutionOrProject, path));
+        }
+
+        private RecursiveDiscoveryResult DiscoverRecursiveProjectFiles(string path, bool isInProjectCone)
+        {
+            var result = new RecursiveDiscoveryResult();
+            var files = _fileSystem.Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly);
+            var directoryContainsCSharpProject = false;
+
+            foreach (var file in files)
+            {
+                if (file.IsCSharpProjectFile())
+                {
+                    result.ProjectFiles.Add(file);
+                    directoryContainsCSharpProject = true;
+                    continue;
+                }
+
+                if (file.IsProjectFile())
+                {
+                    result.ProjectFiles.Add(file);
+                }
+            }
+
+            var currentDirectoryIsInProjectCone = isInProjectCone || directoryContainsCSharpProject;
+            if (!currentDirectoryIsInProjectCone)
+            {
+                foreach (var file in files)
+                {
+                    if (file.IsCSharpFile() && StartsWithShebang(file))
+                    {
+                        result.FileBasedApps.Add(file);
+                    }
+                }
+            }
+
+            var childResults = _fileSystem.Directory.GetDirectories(path, "*", SearchOption.TopDirectoryOnly)
+                .Select(directory => DiscoverRecursiveProjectFiles(directory, currentDirectoryIsInProjectCone))
+                .ToArray();
+
+            foreach (var childResult in childResults)
+            {
+                result.ProjectFiles.AddRange(childResult.ProjectFiles);
+                result.FileBasedApps.AddRange(childResult.FileBasedApps);
+            }
+
+            return result;
+        }
+
+        private bool StartsWithShebang(string file)
+        {
+            using var stream = _fileSystem.File.OpenRead(file);
+            Span<byte> bytes = stackalloc byte[5];
+            var bytesRead = stream.Read(bytes);
+            // Allow scripts saved with a UTF-8 BOM before the shebang.
+            var offset = bytesRead >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF ? 3 : 0;
+
+            return bytesRead - offset >= 2 && bytes[offset] == (byte)'#' && bytes[offset + 1] == (byte)'!';
+        }
+
+        private sealed class RecursiveDiscoveryResult
+        {
+            public List<string> ProjectFiles { get; } = new();
+
+            public List<string> FileBasedApps { get; } = new();
         }
     }
 }

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -5,6 +5,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using DotNetOutdated.Core;
 using NuGet.Versioning;
 
 namespace DotNetOutdated.Core.Services;
@@ -36,10 +37,10 @@ public interface IVariableTrackingService
 public sealed class VariableTrackingService : IVariableTrackingService
 {
     private readonly IFileSystem _fileSystem;
-    private readonly Action<string>? _onWarning;
+    private readonly Action<string> _onWarning;
     private readonly Dictionary<string, Dictionary<string, PackageVariableInfo>> _cache;
 
-    public VariableTrackingService(IFileSystem fileSystem, Action<string>? onWarning = null)
+    public VariableTrackingService(IFileSystem fileSystem, Action<string> onWarning = null)
     {
         _fileSystem = fileSystem;
         _onWarning = onWarning;
@@ -55,6 +56,13 @@ public sealed class VariableTrackingService : IVariableTrackingService
     {
         try
         {
+            if (variableInfo.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType)
+            {
+                UpdateFileBasedAppPackageVariable(variableInfo, newVersion);
+                InvalidateCache(variableInfo.FilePath, variableInfo.PackageReferenceFilePath);
+                return;
+            }
+
             // Step 1: Update the property value in the file where it's defined
             string propertyFilePath = variableInfo.FilePath;
             if (_fileSystem.File.Exists(propertyFilePath))
@@ -108,38 +116,104 @@ public sealed class VariableTrackingService : IVariableTrackingService
                 _fileSystem.File.WriteAllText(packageRefFilePath, packageRefContent);
             }
 
-            // Invalidate cache for the affected project since we modified files
-            var keysToRemove = _cache.Keys.Where(key =>
-            {
-                var projectFile = _fileSystem.FileInfo.New(key);
-                if (!projectFile.Exists) return false;
-
-                // Check if this project or any parent directory contains the modified files
-                var directory = projectFile.Directory;
-                while (directory != null)
-                {
-                    var propertyFileInDir = _fileSystem.Path.Combine(directory.FullName, _fileSystem.Path.GetFileName(propertyFilePath))
-                        .Equals(propertyFilePath, StringComparison.OrdinalIgnoreCase);
-                    var packageFileInDir = _fileSystem.Path.Combine(directory.FullName, _fileSystem.Path.GetFileName(packageRefFilePath))
-                        .Equals(packageRefFilePath, StringComparison.OrdinalIgnoreCase);
-
-                    if (propertyFileInDir || packageFileInDir)
-                    {
-                        return true;
-                    }
-                    directory = directory.Parent;
-                }
-                return false;
-            }).ToList();
-
-            foreach (var key in keysToRemove)
-            {
-                _cache.Remove(key);
-            }
+            InvalidateCache(propertyFilePath, packageRefFilePath);
         }
         catch (Exception ex)
         {
             _onWarning?.Invoke($"Failed to preserve variable reference for '{variableInfo.PackageName}': {ex.Message}");
+        }
+    }
+
+    private void UpdateFileBasedAppPackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
+    {
+        if (_fileSystem.File.Exists(variableInfo.FilePath))
+        {
+            if (variableInfo.FilePath.IsCSharpFile())
+            {
+                var propertyContent = _fileSystem.File.ReadAllText(variableInfo.FilePath);
+                var propertyPattern = $@"(^[ \t]*#:[ \t]*property[ \t]+{Regex.Escape(variableInfo.VariableName)}[ \t]*=[ \t]*)([^\r\n]*)(\r?\n|$)";
+                propertyContent = Regex.Replace(
+                    propertyContent,
+                    propertyPattern,
+                    match => match.Groups[1].Value + newVersion + match.Groups[3].Value,
+                    RegexOptions.Multiline);
+                _fileSystem.File.WriteAllText(variableInfo.FilePath, propertyContent);
+            }
+            else
+            {
+                var propertyContent = _fileSystem.File.ReadAllText(variableInfo.FilePath);
+                var propertyDoc = XDocument.Parse(propertyContent);
+                var propertyElement = propertyDoc.Descendants()
+                    .FirstOrDefault(e => e.Name.LocalName == variableInfo.VariableName &&
+                                         e.Parent?.Name.LocalName == "PropertyGroup");
+
+                if (propertyElement != null)
+                {
+                    string oldValue = propertyElement.Value;
+                    string pattern = $@"<{Regex.Escape(variableInfo.VariableName)}>{Regex.Escape(oldValue)}</{Regex.Escape(variableInfo.VariableName)}>";
+                    string replacement = $"<{variableInfo.VariableName}>{newVersion}</{variableInfo.VariableName}>";
+                    propertyContent = Regex.Replace(propertyContent, pattern, replacement);
+                    _fileSystem.File.WriteAllText(variableInfo.FilePath, propertyContent);
+                }
+            }
+        }
+
+        if (_fileSystem.File.Exists(variableInfo.PackageReferenceFilePath) && variableInfo.PackageReferenceFilePath.IsCSharpFile())
+        {
+            var packageContent = _fileSystem.File.ReadAllText(variableInfo.PackageReferenceFilePath);
+            var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
+            CollectFileBasedAppPropertyDefinitions(variableInfo.PackageReferenceFilePath, propertyDefinitions);
+
+            packageContent = Regex.Replace(
+                packageContent,
+                @"(^[ \t]*#:[ \t]*package[ \t]+)([^\r\n]*)(\r?\n|$)",
+                match =>
+                {
+                    var packageDirective = match.Groups[2].Value;
+                    if (!TryParsePackageDirective(packageDirective, out var packageExpression, out _) ||
+                        (!string.Equals(packageExpression, variableInfo.PackageReferenceName, StringComparison.OrdinalIgnoreCase) &&
+                         (!TryResolveProperties(packageExpression, propertyDefinitions, out var packageName) ||
+                          !string.Equals(packageName, variableInfo.PackageName, StringComparison.OrdinalIgnoreCase))))
+                    {
+                        return match.Value;
+                    }
+
+                    return match.Groups[1].Value + variableInfo.PackageReferenceName + "@" + variableInfo.PackageReferenceVersion + match.Groups[3].Value;
+                },
+                RegexOptions.Multiline);
+
+            _fileSystem.File.WriteAllText(variableInfo.PackageReferenceFilePath, packageContent);
+        }
+    }
+
+    private void InvalidateCache(string propertyFilePath, string packageRefFilePath)
+    {
+        var keysToRemove = _cache.Keys.Where(key =>
+        {
+            var projectFile = _fileSystem.FileInfo.New(key);
+            if (!projectFile.Exists) return false;
+
+            // Check if this project or any parent directory contains the modified files
+            var directory = projectFile.Directory;
+            while (directory != null)
+            {
+                var propertyFileInDir = _fileSystem.Path.Combine(directory.FullName, _fileSystem.Path.GetFileName(propertyFilePath))
+                    .Equals(propertyFilePath, StringComparison.OrdinalIgnoreCase);
+                var packageFileInDir = _fileSystem.Path.Combine(directory.FullName, _fileSystem.Path.GetFileName(packageRefFilePath))
+                    .Equals(packageRefFilePath, StringComparison.OrdinalIgnoreCase);
+
+                if (propertyFileInDir || packageFileInDir)
+                {
+                    return true;
+                }
+                directory = directory.Parent;
+            }
+            return false;
+        }).ToList();
+
+        foreach (var key in keysToRemove)
+        {
+            _cache.Remove(key);
         }
     }
 
@@ -163,8 +237,10 @@ public sealed class VariableTrackingService : IVariableTrackingService
         // First, collect all property definitions from all relevant files
         var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
 
+        var isFileBasedApp = projectFilePath.IsCSharpFile();
+
         // Collect files to scan (project file + all .props files in parent hierarchy)
-        var filesToScan = new List<string> { projectFilePath };
+        var filesToScan = isFileBasedApp ? new List<string>() : new List<string> { projectFilePath };
         var directory = projectFile.Directory;
         while (directory != null)
         {
@@ -176,10 +252,20 @@ public sealed class VariableTrackingService : IVariableTrackingService
             directory = directory.Parent;
         }
 
+        if (isFileBasedApp)
+        {
+            CollectFileBasedAppPropertyDefinitions(projectFilePath, propertyDefinitions);
+        }
+
         // Scan all files for property definitions
         foreach (var fileToScan in filesToScan)
         {
             CollectPropertyDefinitions(fileToScan, propertyDefinitions);
+        }
+
+        if (isFileBasedApp)
+        {
+            ScanFileBasedAppForVariables(projectFilePath, result, propertyDefinitions);
         }
 
         // Now scan all files for package references that use variables
@@ -220,6 +306,24 @@ public sealed class VariableTrackingService : IVariableTrackingService
         catch
         {
             // Silently ignore files that can't be parsed
+        }
+    }
+
+    private void CollectFileBasedAppPropertyDefinitions(string filePath, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    {
+        foreach (var line in _fileSystem.File.ReadLines(filePath))
+        {
+            var match = Regex.Match(line, @"^[ \t]*#:[ \t]*property[ \t]+([^=\s]+)[ \t]*=[ \t]*(.*?)\s*$");
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var propertyName = match.Groups[1].Value;
+            if (!propertyDefinitions.ContainsKey(propertyName))
+            {
+                propertyDefinitions[propertyName] = (match.Groups[2].Value, filePath);
+            }
         }
     }
 
@@ -272,14 +376,91 @@ public sealed class VariableTrackingService : IVariableTrackingService
             // Silently ignore files that can't be parsed
         }
     }
+
+    private void ScanFileBasedAppForVariables(string filePath, Dictionary<string, PackageVariableInfo> result, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    {
+        foreach (var line in _fileSystem.File.ReadLines(filePath))
+        {
+            var match = Regex.Match(line, @"^[ \t]*#:[ \t]*package[ \t]+(.+?)\s*$");
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            if (!TryParsePackageDirective(match.Groups[1].Value, out var packageExpression, out var versionExpression) ||
+                !TryResolveProperties(packageExpression, propertyDefinitions, out var packageName) ||
+                result.ContainsKey(packageName))
+            {
+                continue;
+            }
+
+            var versionMatch = Regex.Match(versionExpression, @"\$\(([^)]+)\)");
+            if (!versionMatch.Success)
+            {
+                continue;
+            }
+
+            string variableName = versionMatch.Groups[1].Value;
+            if (propertyDefinitions.TryGetValue(variableName, out var propertyInfo))
+            {
+                result[packageName] = new PackageVariableInfo
+                {
+                    PackageName = packageName,
+                    VariableName = variableName,
+                    VariableValue = propertyInfo.Value,
+                    FilePath = propertyInfo.FilePath,
+                    PackageReferenceFilePath = filePath,
+                    ElementType = PackageVariableInfo.FileBasedPackageDirectiveElementType,
+                    PackageReferenceName = packageExpression,
+                    PackageReferenceVersion = versionExpression
+                };
+            }
+        }
+    }
+
+    private static bool TryParsePackageDirective(string directive, out string packageExpression, out string versionExpression)
+    {
+        var separatorIndex = directive.LastIndexOf('@');
+        if (separatorIndex <= 0 || separatorIndex == directive.Length - 1)
+        {
+            packageExpression = string.Empty;
+            versionExpression = string.Empty;
+            return false;
+        }
+
+        packageExpression = directive[..separatorIndex].Trim();
+        versionExpression = directive[(separatorIndex + 1)..].Trim();
+        return !string.IsNullOrEmpty(packageExpression) && !string.IsNullOrEmpty(versionExpression);
+    }
+
+    private static bool TryResolveProperties(string expression, Dictionary<string, (string Value, string FilePath)> propertyDefinitions, out string resolvedValue)
+    {
+        var unresolved = false;
+        resolvedValue = Regex.Replace(expression, @"\$\(([^)]+)\)", match =>
+        {
+            if (propertyDefinitions.TryGetValue(match.Groups[1].Value, out var propertyInfo))
+            {
+                return propertyInfo.Value;
+            }
+
+            unresolved = true;
+            return match.Value;
+        });
+
+        return !unresolved;
+    }
 }
 
 public class PackageVariableInfo
 {
+    public const string FileBasedPackageDirectiveElementType = "FileBasedPackageDirective";
+
     public string PackageName { get; set; }
     public string VariableName { get; set; }
     public string VariableValue { get; set; }
     public string FilePath { get; set; }  // Where the property is DEFINED
     public string PackageReferenceFilePath { get; set; }  // Where the PackageReference/PackageVersion is USED
     public string ElementType { get; set; }
+    public string PackageReferenceName { get; set; }
+    public string PackageReferenceVersion { get; set; }
 }

--- a/src/DotNetOutdated/McpServer.cs
+++ b/src/DotNetOutdated/McpServer.cs
@@ -131,14 +131,15 @@ namespace DotNetOutdated
                 new
                 {
                     name = "discover_projects",
-                    description = "Scans a directory for .NET projects (.csproj, .sln, etc.)",
+                    description = "Scans a directory for .NET projects (.csproj, .sln, etc.) and optionally file-based apps",
                     inputSchema = new
                     {
                         type = "object",
                         properties = new
                         {
                             path = new { type = "string", description = "Root path to search" },
-                            recursive = new { type = "boolean", description = "Whether to search recursively" }
+                            recursive = new { type = "boolean", description = "Whether to search recursively" },
+                            includeFileBasedApps = new { type = "boolean", description = "Whether recursive discovery should include loose .cs file-based apps" }
                         },
                         required = new[] { "path" }
                     }
@@ -146,13 +147,13 @@ namespace DotNetOutdated
                 new
                 {
                     name = "analyze_project",
-                    description = "Analyzes a project for outdated packages",
+                    description = "Analyzes a project or file-based app for outdated packages",
                     inputSchema = new
                     {
                         type = "object",
                         properties = new
                         {
-                            projectPath = new { type = "string", description = "Path to the project file" },
+                            projectPath = new { type = "string", description = "Path to the project file or .cs file-based app" },
                             includeTransitive = new { type = "boolean", description = "Check transitive dependencies" }
                         },
                         required = new[] { "projectPath" }
@@ -161,13 +162,13 @@ namespace DotNetOutdated
                 new
                 {
                     name = "update_package",
-                    description = "Updates a specific package in a project",
+                    description = "Updates a specific package in a project or file-based app",
                     inputSchema = new
                     {
                         type = "object",
                         properties = new
                         {
-                            projectPath = new { type = "string", description = "Path to the project" },
+                            projectPath = new { type = "string", description = "Path to the project or .cs file-based app" },
                             packageName = new { type = "string", description = "Name of the package" },
                             version = new { type = "string", description = "Version to upgrade to" },
                             framework = new { type = "string", description = "Target framework" }
@@ -237,7 +238,13 @@ namespace DotNetOutdated
                 recursive = recursiveProp.GetBoolean();
             }
 
-            var projects = _projectDiscoveryService.DiscoverProjects(path, recursive);
+            bool includeFileBasedApps = false;
+            if (arguments.TryGetProperty("includeFileBasedApps", out var includeFileBasedAppsProp))
+            {
+                includeFileBasedApps = includeFileBasedAppsProp.GetBoolean();
+            }
+
+            var projects = _projectDiscoveryService.DiscoverProjects(path, recursive, includeFileBasedApps);
             
             return new
             {

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -50,7 +50,7 @@ namespace DotNetOutdated
           LongName = "include-auto-references")]
       public bool IncludeAutoReferences { get; set; } = false;
 
-      [Argument(0, Description = "The path to a .sln, .slnx, .slnf, .csproj or .fsproj file, or to a directory containing a .NET Core solution/project. " +
+      [Argument(0, Description = "The path to a .sln, .slnx, .slnf, .csproj, .fsproj or .cs file-based app, or to a directory containing a .NET Core solution/project. " +
                                  "If none is specified, the current directory will be used.")]
       public string Path { get; set; }
 
@@ -111,6 +111,10 @@ namespace DotNetOutdated
       [Option(CommandOptionType.NoValue, Description = "Recursively search for all projects within the provided directory.",
           ShortName = "r", LongName = "recursive")]
       public bool Recursive { get; set; } = false;
+
+      [Option(CommandOptionType.NoValue, Description = "Include loose file-based apps when recursively searching a directory.",
+          ShortName = "fba", LongName = "include-file-based-apps")]
+      public bool IncludeFileBasedApps { get; set; } = false;
 
       [Option(CommandOptionType.NoValue, Description = "Treat package source failures as warnings.", ShortName = "ifs", LongName = "ignore-failed-sources")]
       public bool IgnoreFailedSources { get; set; } = false;
@@ -199,7 +203,7 @@ namespace DotNetOutdated
 
             DefaultCredentialServiceUtility.SetupDefaultCredentialService(new ConsoleLogger(console, NuGetCredLogLevel), true);
 
-            var projectPaths = _projectDiscoveryService.DiscoverProjects(Path, Recursive);
+            var projectPaths = _projectDiscoveryService.DiscoverProjects(Path, Recursive, IncludeFileBasedApps);
 
             // Analyze the projects
             console.WriteLine("Analyzing project(s)...");
@@ -305,7 +309,7 @@ namespace DotNetOutdated
                   }
 
                   if (status is null || status.IsSuccess)
-                     status = _dotNetPackageService.AddPackage(project.ProjectFilePath, package.Name, project.Framework.ToString(), package.LatestVersion, NoRestore, IgnoreFailedSources);
+                     status = _dotNetPackageService.AddPackage(project.ProjectFilePath, package.Name, project.Framework.GetShortFolderName(), package.LatestVersion, NoRestore, IgnoreFailedSources);
 
                   if (status.IsSuccess)
                   {

--- a/src/DotNetOutdated/ProjectExtensions.cs
+++ b/src/DotNetOutdated/ProjectExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using DotNetOutdated.Core;
 using DotNetOutdated.Models;
 
 namespace DotNetOutdated
@@ -60,6 +61,11 @@ namespace DotNetOutdated
 
         public static bool IsProjectSdkStyle(this PackageProjectReference project)
         {
+            if (project.ProjectFilePath.IsCSharpFile())
+            {
+                return true;
+            }
+
             try
             {
                 var xml = XDocument.Load(project.ProjectFilePath);

--- a/test-projects/file-based-app-direct-package/app.cs
+++ b/test-projects/file-based-app-direct-package/app.cs
@@ -1,0 +1,7 @@
+#!/usr/bin/env dotnet
+#:property TargetFramework=net10.0
+#:package Newtonsoft.Json@11.0.1
+
+using Newtonsoft.Json;
+
+Console.WriteLine(JsonConvert.SerializeObject(new { Message = "Hello from a direct package directive" }));

--- a/test-projects/file-based-app/app.cs
+++ b/test-projects/file-based-app/app.cs
@@ -1,0 +1,9 @@
+#!/usr/bin/env dotnet
+#:property TargetFramework=net10.0
+#:property NewtonsoftJsonPackageId=Newtonsoft.Json
+#:property NewtonsoftJsonPackageVersion=11.0.1
+#:package $(NewtonsoftJsonPackageId)@$(NewtonsoftJsonPackageVersion)
+
+using Newtonsoft.Json;
+
+Console.WriteLine(JsonConvert.SerializeObject(new { Message = "Hello from a file-based app" }));

--- a/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
@@ -101,5 +101,35 @@ namespace DotNetOutdated.Tests
 
             dotNetRunner.Received().Run(_path, Arg.Is<string[]>(a => a[0] == "msbuild" && a[1] == _solutionPath && a[4] == "/t:Restore,GenerateRestoreGraphFile"));
         }
+
+        [Fact]
+        public async Task FileBasedAppGeneratesDependencyGraphWithRestoreThenBuild()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var appPath = XFS.Path(@"c:\path\app.cs");
+
+            // Arrange
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            dotNetRunner.Run(Arg.Any<string>(), Arg.Is<string[]>(a => a[0] == "restore"))
+                .Returns(new RunStatus(string.Empty, string.Empty, 0));
+            dotNetRunner.Run(Arg.Any<string>(), Arg.Is<string[]>(a => a[0] == "build"))
+                .Returns(new RunStatus(string.Empty, string.Empty, 0))
+                .AndDoes(x =>
+                {
+                    var arguments = x.ArgAt<string[]>(1);
+                    string tempFileName = arguments[6].Replace("/p:RestoreGraphOutputPath=", string.Empty, StringComparison.OrdinalIgnoreCase).Trim('"');
+                    mockFileSystem.AddFileFromEmbeddedResource(tempFileName, GetType().Assembly, "DotNetOutdated.Tests.TestData.test.dg");
+                });
+
+            var graphService = new DependencyGraphService(dotNetRunner, mockFileSystem);
+
+            // Act
+            var dependencyGraph = await graphService.GenerateDependencyGraphAsync(appPath, string.Empty);
+
+            // Assert
+            Assert.NotNull(dependencyGraph);
+            dotNetRunner.Received().Run(_path, Arg.Is<string[]>(a => a[0] == "restore" && a[1] == appPath));
+            dotNetRunner.Received().Run(_path, Arg.Is<string[]>(a => a[0] == "build" && a[1] == appPath && a[2] == "--no-restore" && a[5] == "/t:GenerateRestoreGraphFile"));
+        }
     }
 }

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -250,5 +250,38 @@ Console.WriteLine();")
             Assert.True(result.IsSuccess);
             dotNetRunner.Received().Run(XFS.Path(@"c:\repo"), Arg.Is<string[]>(a => a[0] == "restore" && a[1] == "app.cs"));
         }
+
+        [Fact]
+        public void FileBasedAppDirectPackage_FallsThroughToDotNetAddPackage()
+        {
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#!/usr/bin/env dotnet
+#:package Humanizer@3.0.10
+Console.WriteLine();")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            dotNetRunner.Run(default, default).ReturnsForAnyArgs(new RunStatus("", "", 0));
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Humanizer", "net10.0", new NuGetVersion("3.0.11"), noRestore: true);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.Received().Run(
+                XFS.Path(@"c:\repo"),
+                Arg.Is<string[]>(a =>
+                    a[0] == "add" &&
+                    a[1] == "app.cs" &&
+                    a[2] == "package" &&
+                    a[3] == "Humanizer" &&
+                    a[4] == "-v" &&
+                    a[5] == "3.0.11" &&
+                    a[6] == "-f" &&
+                    a[7] == "net10.0" &&
+                    a[8] == "--no-restore"));
+        }
     }
 }

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -201,5 +201,54 @@ namespace DotNetOutdated.Tests
             // Assert - should fall through to dotnet add package
             dotNetRunner.ReceivedWithAnyArgs(1).Run(default, default);
         }
+
+        [Fact]
+        public void FileBasedAppVariablePackageWithNoRestore_UpdatesVariableWithoutCallingDotNet()
+        {
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#!/usr/bin/env dotnet
+#:property HumanizerPackageId=Humanizer
+#:property HumanizerPackageVersion=3.0.10
+#:package $(HumanizerPackageId)@$(HumanizerPackageVersion)
+Console.WriteLine();")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Humanizer", "net10.0", new NuGetVersion("3.0.11"), noRestore: true);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:property HumanizerPackageVersion=3.0.11", content);
+            Assert.Contains("#:package $(HumanizerPackageId)@$(HumanizerPackageVersion)", content);
+        }
+
+        [Fact]
+        public void FileBasedAppVariablePackageWithRestore_UpdatesVariableAndRunsRestore()
+        {
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#!/usr/bin/env dotnet
+#:property HumanizerPackageVersion=3.0.10
+#:package Humanizer@$(HumanizerPackageVersion)
+Console.WriteLine();")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            dotNetRunner.Run(default, default).ReturnsForAnyArgs(new RunStatus("", "", 0));
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Humanizer", "net10.0", new NuGetVersion("3.0.11"), noRestore: false);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.Received().Run(XFS.Path(@"c:\repo"), Arg.Is<string[]>(a => a[0] == "restore" && a[1] == "app.cs"));
+        }
     }
 }

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -111,6 +111,22 @@ public static class EndToEndTests
         Assert.DoesNotContain("#:property NewtonsoftJsonPackageVersion=11.0.1", content);
     }
 
+    [RequiresFileBasedAppSdk]
+    public static void Can_Upgrade_File_Based_App_With_Direct_Package_Directive()
+    {
+        using var project = TestSetup("file-based-app-direct-package");
+
+        var appPath = Path.Combine(project.Path, "app.cs");
+
+        var actual = Program.Main([appPath, "--upgrade", "--no-restore"]);
+        Assert.Equal(0, actual);
+
+        var content = File.ReadAllText(appPath);
+
+        Assert.Contains("#:package Newtonsoft.Json@", content);
+        Assert.DoesNotContain("#:package Newtonsoft.Json@11.0.1", content);
+    }
+
     [Fact]
     public static void Can_Upgrade_Project_With_Maximum_Version()
     {

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -61,6 +63,52 @@ public static class EndToEndTests
 
         var actual = Program.Main([project.Path, "--output", outputPath, "--output-format", format.ToString()]);
         Assert.Equal(0, actual);
+    }
+
+    [RequiresFileBasedAppSdk]
+    public static void Can_Analyze_File_Based_App()
+    {
+        using var project = TestSetup("file-based-app");
+
+        var appPath = Path.Combine(project.Path, "app.cs");
+        var outputPath = Path.Combine(project.Path, "output.json");
+
+        var actual = Program.Main([appPath, "--output", outputPath, "--output-format:json"]);
+        Assert.Equal(0, actual);
+
+        using var output = JsonDocument.Parse(File.ReadAllText(outputPath));
+        var analyzedProject = Assert.Single(output.RootElement.GetProperty("Projects").EnumerateArray());
+
+        Assert.Equal("app.cs", analyzedProject.GetProperty("Name").GetString());
+        Assert.Equal(Path.GetFullPath(appPath), analyzedProject.GetProperty("FilePath").GetString());
+
+        var analyzedDependency = Assert.Single(
+            analyzedProject
+                .GetProperty("TargetFrameworks")
+                .EnumerateArray()
+                .SelectMany(targetFramework => targetFramework.GetProperty("Dependencies").EnumerateArray()),
+            dependency => dependency.GetProperty("Name").GetString() == "Newtonsoft.Json");
+
+        Assert.Equal("11.0.1", analyzedDependency.GetProperty("ResolvedVersion").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(analyzedDependency.GetProperty("LatestVersion").GetString()));
+    }
+
+    [RequiresFileBasedAppSdk]
+    public static void Can_Upgrade_File_Based_App_With_Variables_Preserves_Variable_References()
+    {
+        using var project = TestSetup("file-based-app");
+
+        var appPath = Path.Combine(project.Path, "app.cs");
+
+        var actual = Program.Main([appPath, "--upgrade", "--no-restore"]);
+        Assert.Equal(0, actual);
+
+        var content = File.ReadAllText(appPath);
+
+        Assert.Contains("#:property NewtonsoftJsonPackageId=Newtonsoft.Json", content);
+        Assert.Contains("#:property NewtonsoftJsonPackageVersion=", content);
+        Assert.Contains("#:package $(NewtonsoftJsonPackageId)@$(NewtonsoftJsonPackageVersion)", content);
+        Assert.DoesNotContain("#:property NewtonsoftJsonPackageVersion=11.0.1", content);
     }
 
     [Fact]
@@ -198,6 +246,64 @@ public static class EndToEndTests
         {
             const string Prefix = "dotnet-bumper-";
             return Directory.CreateTempSubdirectory(Prefix);
+        }
+    }
+
+    public sealed class RequiresFileBasedAppSdkAttribute : FactAttribute
+    {
+        private static readonly Version MinimumSdkVersion = new(10, 0, 300);
+
+        public RequiresFileBasedAppSdkAttribute()
+        {
+            if (!DotNetSdkDetector.HasSdkVersionAtLeast(MinimumSdkVersion))
+            {
+                Skip = $"Requires .NET SDK {MinimumSdkVersion} or newer.";
+            }
+        }
+    }
+
+    internal static class DotNetSdkDetector
+    {
+        public static bool HasSdkVersionAtLeast(Version minimumVersion)
+        {
+            try
+            {
+                using var process = Process.Start(new ProcessStartInfo("dotnet", "--list-sdks")
+                {
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false
+                });
+
+                if (process is null)
+                {
+                    return false;
+                }
+
+                var output = process.StandardOutput.ReadToEnd();
+
+                if (!process.WaitForExit(milliseconds: 10_000))
+                {
+                    process.Kill(entireProcessTree: true);
+                    return false;
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    return false;
+                }
+
+                return output
+                    .Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries)
+                    .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
+                    .Where(sdkVersion => !string.IsNullOrWhiteSpace(sdkVersion))
+                    .Select(sdkVersion => sdkVersion!.Split('-')[0])
+                    .Any(sdkVersion => Version.TryParse(sdkVersion, out var version) && version.CompareTo(minimumVersion) >= 0);
+            }
+            catch (Win32Exception)
+            {
+                return false;
+            }
         }
     }
 }

--- a/test/DotNetOutdated.Tests/ProjectDiscoveryServiceTests.cs
+++ b/test/DotNetOutdated.Tests/ProjectDiscoveryServiceTests.cs
@@ -13,7 +13,11 @@ namespace DotNetOutdated.Tests
 {
     public class ProjectDiscoveryServiceTests
     {
-        private readonly string _nonProjectFile = XFS.Path(@"c:\path\file.cs");
+        private readonly string _nonProjectFile = XFS.Path(@"c:\path\file.txt");
+        private readonly string _fileBasedApp = XFS.Path(@"c:\path\app.cs");
+        private readonly string _looseFileBasedApp = XFS.Path(@"c:\path\scripts\app.cs");
+        private readonly string _looseNonFileBasedApp = XFS.Path(@"c:\path\scripts\ignored.cs");
+        private readonly string _projectConeFileBasedApp = XFS.Path(@"c:\path\sub\script.cs");
         private readonly string _path = XFS.Path(@"c:\path");
         private readonly string _project1 = XFS.Path(@"c:\path\project1.csproj");
         private readonly string _project2 = XFS.Path(@"c:\path\project2.csproj");
@@ -146,6 +150,65 @@ namespace DotNetOutdated.Tests
 
             // Assert
             Assert.Throws<CommandValidationException>(() => projectDiscoveryService.DiscoverProjects(_nonProjectFile));
+        }
+
+        [Fact]
+        public void FileBasedAppReturnsFile()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { _fileBasedApp, new MockFileData("Console.WriteLine();")}
+            }, _path);
+            var projectDiscoveryService = new ProjectDiscoveryService(fileSystem);
+
+            // Act
+            string project = projectDiscoveryService.DiscoverProjects(_fileBasedApp).Single();
+
+            // Assert
+            Assert.Equal(_fileBasedApp, project);
+        }
+
+        [Fact]
+        public void RecursiveDoesNotIncludeLooseShebangFileBasedAppsByDefault()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { _project4, Singletons.NullObject},
+                { _looseFileBasedApp, new MockFileData("#!/usr/bin/env dotnet\n#:package Humanizer@2.14.1")}
+            }, _path);
+            var projectDiscoveryService = new ProjectDiscoveryService(fileSystem);
+
+            // Act
+            var projects = projectDiscoveryService.DiscoverProjects(_path, true);
+
+            // Assert
+            Assert.DoesNotContain(_looseFileBasedApp, projects);
+            Assert.Contains(_project4, projects);
+        }
+
+        [Fact]
+        public void RecursiveIncludesLooseShebangFileBasedAppsWhenEnabled()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { _project4, Singletons.NullObject},
+                { _looseFileBasedApp, new MockFileData("#!/usr/bin/env dotnet\n#:package Humanizer@2.14.1")},
+                { _looseNonFileBasedApp, new MockFileData("#:package Humanizer@2.14.1")},
+                { _projectConeFileBasedApp, new MockFileData("#!/usr/bin/env dotnet\n#:package Humanizer@2.14.1")}
+            }, _path);
+            var projectDiscoveryService = new ProjectDiscoveryService(fileSystem);
+
+            // Act
+            var projects = projectDiscoveryService.DiscoverProjects(_path, true, includeFileBasedApps: true);
+
+            // Assert
+            Assert.Contains(_looseFileBasedApp, projects);
+            Assert.DoesNotContain(_looseNonFileBasedApp, projects);
+            Assert.DoesNotContain(_projectConeFileBasedApp, projects);
+            Assert.Contains(_project4, projects);
         }
 
         [Fact]

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -515,5 +515,88 @@ namespace DotNetOutdated.Tests
             var after = service.DiscoverPackageVariables(projectPath);
             Assert.Equal("13.0.1", after["Newtonsoft.Json"].VariableValue);
         }
+
+        [Fact]
+        public void Discover_FileBasedApp_VariablePackageDirective()
+        {
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#!/usr/bin/env dotnet
+#:property HumanizerPackageId=Humanizer
+#:property HumanizerPackageVersion=3.0.10
+#:package $(HumanizerPackageId)@$(HumanizerPackageVersion)
+Console.WriteLine();")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var result = service.DiscoverPackageVariables(appPath);
+
+            var info = Assert.Contains("Humanizer", result);
+            Assert.Equal("HumanizerPackageVersion", info.VariableName);
+            Assert.Equal("3.0.10", info.VariableValue);
+            Assert.Equal(appPath, info.FilePath);
+            Assert.Equal(appPath, info.PackageReferenceFilePath);
+            Assert.Equal(PackageVariableInfo.FileBasedPackageDirectiveElementType, info.ElementType);
+            Assert.Equal("$(HumanizerPackageId)", info.PackageReferenceName);
+            Assert.Equal("$(HumanizerPackageVersion)", info.PackageReferenceVersion);
+        }
+
+        [Fact]
+        public void Update_FileBasedApp_UpdatesPropertyAndPreservesPackageDirectiveVariables()
+        {
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#!/usr/bin/env dotnet
+#:property HumanizerPackageId=Humanizer
+#:property HumanizerPackageVersion=3.0.10
+#:package $(HumanizerPackageId)@$(HumanizerPackageVersion)
+Console.WriteLine();")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var variableInfo = service.DiscoverPackageVariables(appPath)["Humanizer"];
+
+            service.UpdatePackageVariable(variableInfo, new NuGetVersion("3.0.11"));
+
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:property HumanizerPackageVersion=3.0.11", content);
+            Assert.Contains("#:package $(HumanizerPackageId)@$(HumanizerPackageVersion)", content);
+            Assert.DoesNotContain("3.0.10", content);
+        }
+
+        [Fact]
+        public void Discover_FileBasedApp_PackageVersionVariableCanComeFromPropsFile()
+        {
+            var propsPath = XFS.Path(@"c:\repo\Directory.Build.props");
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    propsPath, new MockFileData(@"<Project>
+  <PropertyGroup>
+    <HumanizerPackageVersion>3.0.10</HumanizerPackageVersion>
+  </PropertyGroup>
+</Project>")
+                },
+                {
+                    appPath, new MockFileData(@"#!/usr/bin/env dotnet
+#:package Humanizer@$(HumanizerPackageVersion)
+Console.WriteLine();")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var result = service.DiscoverPackageVariables(appPath);
+
+            var info = Assert.Contains("Humanizer", result);
+            Assert.Equal(propsPath, info.FilePath);
+            Assert.Equal("3.0.10", info.VariableValue);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add support for targeting .NET file-based apps via `.cs` paths
- Generate restore graphs for file-based apps and map virtual SDK project paths back to source files
- Update `#:package` directives, including variable-backed versions through `#:property`
- Add opt-in recursive loose FBA discovery via `--include-file-based-apps` / `-fba`
- Document FBA behavior and add tests for discovery, graph generation, variable tracking, package updates, and SDK-backed FBA end-to-end coverage
- Add explicit CI coverage for file-based apps with .NET SDK 10.0.300 on Ubuntu, Windows, and macOS

## Validation
- `dotnet test --configuration Release`
- `dotnet test --configuration Release --framework net9.0 --filter "FullyQualifiedName~File_Based_App"`
- `dotnet run --configuration Release --framework net9.0 --project src\DotNetOutdated -- test-projects\file-based-app\app.cs --fail-on-updates`
- Fork PR checks: 9/9 passing, including explicit `.NET SDK 10.0.300` file-based app jobs on Ubuntu, Windows, and macOS