### PR TITLE
Add `#:sdk` support for .NET file-based apps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,5 +80,21 @@ jobs:
 
         exit 0
 
+    - name: File-based app SDK smoke test
+      shell: pwsh
+      run: |
+        if (Get-Variable PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+          $PSNativeCommandUseErrorActionPreference = $false
+        }
+
+        & dotnet run --configuration Release --framework net9.0 --project src/DotNetOutdated -- test-projects/file-based-app-sdk/app.cs --fail-on-updates
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -ne 2) {
+          throw "Expected file-based app SDK smoke test to exit with 2 because outdated SDK dependencies were found, but got $exitCode."
+        }
+
+        exit 0
+
     - name: File-based app tests
       run: dotnet test --configuration Release --framework net9.0 --filter "FullyQualifiedName~FileBasedApp|FullyQualifiedName~File_Based_App"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Lastly, you can specify the path to a solution (`.sln` or `.slnx`), project (`.c
 
 When `--recursive --include-file-based-apps` is used, **dotnet-outdated** also discovers loose `.cs` file-based apps that start with a shebang (`#!`). `.cs` files under a `.csproj` directory tree are ignored during recursive file-based app discovery.
 
+File-based apps can declare NuGet packages with `#:package` and MSBuild SDK packages with `#:sdk` (for example `#:sdk Cake.Sdk@6.0.0`). Variable-backed versions use `#:property` the same way as for packages.
+
 ## Upgrading packages
 
 **dotnet-outdated** can automatically attempt to upgrade any outdated packages to the latest version by passing the `-u|--upgrade` option. You can let **dotnet-outdated** prompt you for each outdated package by using the `-u:prompt` option.
@@ -242,7 +244,7 @@ Add the following to your `.vscode/mcp.json`:
 
 ### Why are unrelated changes made to .csproj files when running with `-u`?
 
-`dotnet-outdated` does not make changes to .csproj files directly. Instead, it runs `dotnet add package` to update packages, so that command is responsible for those changes. For file-based apps that use variable-backed `#:package` directives, `dotnet-outdated` updates the referenced `#:property` value directly so the variable reference is preserved. To track issues related to the .NET CLI command, head over to the [.NET CLI repo](https://github.com/dotnet/cli)
+`dotnet-outdated` does not make changes to .csproj files directly. Instead, it runs `dotnet add package` to update packages, so that command is responsible for those changes. For file-based apps that use variable-backed `#:package` or `#:sdk` directives, `dotnet-outdated` updates the referenced `#:property` value directly so the variable reference is preserved. Literal `#:package` and `#:sdk` directives are updated in the `.cs` source file. To track issues related to the .NET CLI command, head over to the [.NET SDK repo](https://github.com/dotnet/sdk)
 
 ### Why I am getting an error about required library hostfxr.dll/libhostfxr.so/libhostfxr.dylib not found?
 

--- a/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
@@ -31,7 +31,7 @@ namespace DotNetOutdated.Core.Services
             if (variableInfo?.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType ||
                 variableInfo?.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType)
             {
-                if (!_variableTrackingService.UpdatePackageVariable(variableInfo, version) &&
+                if (!_variableTrackingService.TryUpdatePackageVariable(variableInfo, version) &&
                     !IsFileBasedAppVariableAtRequestedVersion(variableInfo, version))
                 {
                     return FileBasedAppUpdateFailed(

--- a/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
@@ -1,8 +1,10 @@
-﻿using NuGet.Versioning;
+﻿using DotNetOutdated.Core;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace DotNetOutdated.Core.Services
@@ -26,12 +28,42 @@ namespace DotNetOutdated.Core.Services
             var variables = _variableTrackingService.DiscoverPackageVariables(projectPath);
             variables.TryGetValue(packageName, out PackageVariableInfo variableInfo);
 
-            if (variableInfo?.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType)
+            if (variableInfo?.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType ||
+                variableInfo?.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType)
             {
-                _variableTrackingService.UpdatePackageVariable(variableInfo, version);
+                if (!_variableTrackingService.UpdatePackageVariable(variableInfo, version))
+                {
+                    return FileBasedAppUpdateFailed(projectPath, packageName);
+                }
+
                 return noRestore
                     ? new RunStatus(string.Empty, string.Empty, 0)
                     : RestoreProject(projectPath, ignoreFailedSources);
+            }
+
+            if (projectPath.IsCSharpFile())
+            {
+                var fileBasedReference = _variableTrackingService.DiscoverFileBasedAppReferences(projectPath)
+                    .FirstOrDefault(reference =>
+                        string.Equals(reference.Name, packageName, StringComparison.OrdinalIgnoreCase) &&
+                        reference.VariableInfo == null);
+
+                if (fileBasedReference?.Kind == FileBasedAppReferenceKind.Sdk)
+                {
+                    if (fileBasedReference.UsesPropertyReferences)
+                    {
+                        return FileBasedAppUpdateFailed(projectPath, packageName);
+                    }
+
+                    if (!_variableTrackingService.UpdateFileBasedAppDirectReference(projectPath, packageName, fileBasedReference.Kind, version))
+                    {
+                        return FileBasedAppUpdateFailed(projectPath, packageName);
+                    }
+
+                    return noRestore
+                        ? new RunStatus(string.Empty, string.Empty, 0)
+                        : RestoreProject(projectPath, ignoreFailedSources);
+                }
             }
 
             // When --no-restore is used, `dotnet add package` has an upstream bug where it writes
@@ -56,7 +88,14 @@ namespace DotNetOutdated.Core.Services
 
             string projectName = _fileSystem.Path.GetFileName(projectPath);
 
-            List<string> arguments = ["add", projectName, "package", packageName, "-v", version.ToString(), "-f", frameworkName];
+            List<string> arguments = ["add", projectName, "package", packageName, "-v", version.ToString()];
+            // File-based apps declare TargetFramework via #:property; dotnet add rejects -f on .cs paths with newer SDKs.
+            if (!projectPath.IsCSharpFile())
+            {
+                arguments.Add("-f");
+                arguments.Add(frameworkName);
+            }
+
             if (noRestore)
             {
                 arguments.Add("--no-restore");
@@ -144,5 +183,11 @@ namespace DotNetOutdated.Core.Services
 
             return false;
         }
+
+        private static RunStatus FileBasedAppUpdateFailed(string projectPath, string packageName) =>
+            new(
+                string.Empty,
+                $"Failed to update file-based app '{projectPath}' for '{packageName}'. No matching directive was changed.",
+                1);
     }
 }

--- a/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
@@ -31,7 +31,8 @@ namespace DotNetOutdated.Core.Services
             if (variableInfo?.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType ||
                 variableInfo?.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType)
             {
-                if (!_variableTrackingService.UpdatePackageVariable(variableInfo, version))
+                if (!_variableTrackingService.UpdatePackageVariable(variableInfo, version) &&
+                    !IsFileBasedAppVariableAtRequestedVersion(variableInfo, version))
                 {
                     return FileBasedAppUpdateFailed(
                         projectPath,
@@ -62,7 +63,8 @@ namespace DotNetOutdated.Core.Services
                             "property references in the name or version must be changed via #:property lines.");
                     }
 
-                    if (!_variableTrackingService.UpdateFileBasedAppDirectReference(projectPath, packageName, fileBasedReference.Kind, version))
+                    if (!_variableTrackingService.UpdateFileBasedAppDirectReference(projectPath, packageName, fileBasedReference.Kind, version) &&
+                        !IsFileBasedAppDirectReferenceAtRequestedVersion(fileBasedReference, version))
                     {
                         return FileBasedAppUpdateFailed(
                             projectPath,
@@ -199,5 +201,18 @@ namespace DotNetOutdated.Core.Services
                 string.Empty,
                 $"Failed to update file-based app '{projectPath}' for '{packageName}'. {hint}",
                 1);
+
+        private static bool IsFileBasedAppVariableAtRequestedVersion(PackageVariableInfo variableInfo, NuGetVersion version)
+        {
+            if (NuGetVersion.TryParse(variableInfo.VariableValue, out var current))
+            {
+                return current == version;
+            }
+
+            return string.Equals(variableInfo.VariableValue, version.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsFileBasedAppDirectReferenceAtRequestedVersion(FileBasedAppReference reference, NuGetVersion version) =>
+            reference.ResolvedVersion == version;
     }
 }

--- a/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
+++ b/src/DotNetOutdated.Core/Services/DotNetPackageService.cs
@@ -33,7 +33,10 @@ namespace DotNetOutdated.Core.Services
             {
                 if (!_variableTrackingService.UpdatePackageVariable(variableInfo, version))
                 {
-                    return FileBasedAppUpdateFailed(projectPath, packageName);
+                    return FileBasedAppUpdateFailed(
+                        projectPath,
+                        packageName,
+                        "Could not update the matching #:property value or #:package/#:sdk directive.");
                 }
 
                 return noRestore
@@ -52,12 +55,19 @@ namespace DotNetOutdated.Core.Services
                 {
                     if (fileBasedReference.UsesPropertyReferences)
                     {
-                        return FileBasedAppUpdateFailed(projectPath, packageName);
+                        return FileBasedAppUpdateFailed(
+                            projectPath,
+                            packageName,
+                            "Direct #:sdk updates require a literal id@version (for example #:sdk Cake.Sdk@6.0.0); " +
+                            "property references in the name or version must be changed via #:property lines.");
                     }
 
                     if (!_variableTrackingService.UpdateFileBasedAppDirectReference(projectPath, packageName, fileBasedReference.Kind, version))
                     {
-                        return FileBasedAppUpdateFailed(projectPath, packageName);
+                        return FileBasedAppUpdateFailed(
+                            projectPath,
+                            packageName,
+                            $"Expected a literal #:sdk {packageName}@<version> directive (id match is case-insensitive; trailing comments are preserved).");
                     }
 
                     return noRestore
@@ -184,10 +194,10 @@ namespace DotNetOutdated.Core.Services
             return false;
         }
 
-        private static RunStatus FileBasedAppUpdateFailed(string projectPath, string packageName) =>
+        private static RunStatus FileBasedAppUpdateFailed(string projectPath, string packageName, string hint) =>
             new(
                 string.Empty,
-                $"Failed to update file-based app '{projectPath}' for '{packageName}'. No matching directive was changed.",
+                $"Failed to update file-based app '{projectPath}' for '{packageName}'. {hint}",
                 1);
     }
 }

--- a/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
+++ b/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
@@ -1,0 +1,85 @@
+using NuGet.Versioning;
+
+namespace DotNetOutdated.Core.Services;
+
+/// <summary>
+/// A package or SDK reference declared in a .NET file-based app source file via <c>#:package</c> or <c>#:sdk</c>.
+/// </summary>
+public sealed class FileBasedAppReference
+{
+    /// <summary>
+    /// Gets the NuGet package or SDK package id.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the resolved semantic version from the source file.
+    /// </summary>
+    public NuGetVersion ResolvedVersion { get; init; }
+
+    /// <summary>
+    /// Gets the version range used when resolving the latest version on NuGet feeds.
+    /// </summary>
+    public VersionRange VersionRange { get; init; }
+
+    /// <summary>
+    /// Gets whether the reference came from a <c>#:package</c> or <c>#:sdk</c> directive.
+    /// </summary>
+    public FileBasedAppReferenceKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the unresolved package or SDK id expression from the source directive (for example <c>Cake.Sdk</c> or <c>$(SdkId)</c>).
+    /// </summary>
+    public string NameExpression { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the unresolved version expression from the source directive (for example <c>6.0.0</c> or <c>$(SdkVersion)</c>).
+    /// </summary>
+    public string VersionExpression { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets variable-tracking metadata when the directive uses a <c>#:property</c>-backed version; otherwise <see langword="null"/>.
+    /// </summary>
+    public PackageVariableInfo VariableInfo { get; init; }
+
+    /// <summary>
+    /// Gets whether either directive expression contains an MSBuild property reference such as <c>$(PropertyName)</c>.
+    /// </summary>
+    public bool UsesPropertyReferences =>
+        FileBasedAppReferenceHelper.ContainsPropertyReference(NameExpression, VersionExpression);
+}
+
+/// <summary>
+/// Helpers for file-based app directive expressions.
+/// </summary>
+internal static class FileBasedAppReferenceHelper
+{
+    /// <summary>
+    /// Determines whether either expression contains an MSBuild property reference.
+    /// </summary>
+    public static bool ContainsPropertyReference(string nameExpression, string versionExpression) =>
+        ExpressionContainsPropertyReference(nameExpression) ||
+        ExpressionContainsPropertyReference(versionExpression);
+
+    /// <summary>
+    /// Determines whether a single expression contains an MSBuild property reference.
+    /// </summary>
+    public static bool ExpressionContainsPropertyReference(string expression) =>
+        !string.IsNullOrEmpty(expression) && expression.Contains("$(");
+}
+
+/// <summary>
+/// The kind of file-based app directive that declared a reference.
+/// </summary>
+public enum FileBasedAppReferenceKind
+{
+    /// <summary>
+    /// A <c>#:package</c> directive.
+    /// </summary>
+    Package,
+
+    /// <summary>
+    /// A <c>#:sdk</c> directive.
+    /// </summary>
+    Sdk
+}

--- a/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
+++ b/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
@@ -20,7 +20,8 @@ public sealed class FileBasedAppReference
     public required NuGetVersion ResolvedVersion { get; init; }
 
     /// <summary>
-    /// Gets the exact version range used when resolving the latest version on NuGet feeds.
+    /// Gets the version range used when resolving the latest version on NuGet feeds. The resolved version is the
+    /// inclusive floor with an open upper bound so newer versions can be discovered.
     /// </summary>
     public required VersionRange VersionRange { get; init; }
 
@@ -70,10 +71,11 @@ internal static class FileBasedAppReferenceHelper
         !string.IsNullOrEmpty(expression) && expression.Contains("$(");
 
     /// <summary>
-    /// Creates an exact inclusive version range for a pinned directive version.
+    /// Creates a minimum-inclusive version range (<c>[version, )</c>) for a directive version. The directive
+    /// version is the current floor, but the range is left open above it so newer versions can be discovered.
     /// </summary>
-    public static VersionRange CreateExactVersionRange(NuGetVersion version) =>
-        new(version, includeMinVersion: true, maxVersion: version, includeMaxVersion: true);
+    public static VersionRange CreateMinimumVersionRange(NuGetVersion version) =>
+        new(version, includeMinVersion: true, maxVersion: null, includeMaxVersion: false);
 
     /// <summary>
     /// Gets the dictionary key for storing a file-based app reference in <see cref="Models.TargetFramework.Dependencies"/>.

--- a/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
+++ b/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
@@ -1,5 +1,7 @@
 using NuGet.Versioning;
 
+#nullable enable
+
 namespace DotNetOutdated.Core.Services;
 
 /// <summary>
@@ -15,12 +17,12 @@ public sealed class FileBasedAppReference
     /// <summary>
     /// Gets the resolved semantic version from the source file.
     /// </summary>
-    public NuGetVersion ResolvedVersion { get; init; }
+    public required NuGetVersion ResolvedVersion { get; init; }
 
     /// <summary>
-    /// Gets the version range used when resolving the latest version on NuGet feeds.
+    /// Gets the exact version range used when resolving the latest version on NuGet feeds.
     /// </summary>
-    public VersionRange VersionRange { get; init; }
+    public required VersionRange VersionRange { get; init; }
 
     /// <summary>
     /// Gets whether the reference came from a <c>#:package</c> or <c>#:sdk</c> directive.
@@ -40,7 +42,7 @@ public sealed class FileBasedAppReference
     /// <summary>
     /// Gets variable-tracking metadata when the directive uses a <c>#:property</c>-backed version; otherwise <see langword="null"/>.
     /// </summary>
-    public PackageVariableInfo VariableInfo { get; init; }
+    public PackageVariableInfo? VariableInfo { get; init; }
 
     /// <summary>
     /// Gets whether either directive expression contains an MSBuild property reference such as <c>$(PropertyName)</c>.
@@ -66,6 +68,12 @@ internal static class FileBasedAppReferenceHelper
     /// </summary>
     public static bool ExpressionContainsPropertyReference(string expression) =>
         !string.IsNullOrEmpty(expression) && expression.Contains("$(");
+
+    /// <summary>
+    /// Creates an exact inclusive version range for a pinned directive version.
+    /// </summary>
+    public static VersionRange CreateExactVersionRange(NuGetVersion version) =>
+        new(version, includeMinVersion: true, maxVersion: version, includeMaxVersion: true);
 }
 
 /// <summary>

--- a/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
+++ b/src/DotNetOutdated.Core/Services/FileBasedAppReference.cs
@@ -74,6 +74,24 @@ internal static class FileBasedAppReferenceHelper
     /// </summary>
     public static VersionRange CreateExactVersionRange(NuGetVersion version) =>
         new(version, includeMinVersion: true, maxVersion: version, includeMaxVersion: true);
+
+    /// <summary>
+    /// Gets the dictionary key for storing a file-based app reference in <see cref="Models.TargetFramework.Dependencies"/>.
+    /// Package and SDK directives with the same id use distinct keys.
+    /// </summary>
+    public static string GetDependencyDictionaryKey(FileBasedAppReference reference) =>
+        GetDependencyDictionaryKey(reference.Name, reference.Kind);
+
+    /// <summary>
+    /// Gets the dictionary key for storing a file-based app reference in <see cref="Models.TargetFramework.Dependencies"/>.
+    /// </summary>
+    public static string GetDependencyDictionaryKey(string name, FileBasedAppReferenceKind kind) =>
+        kind switch
+        {
+            FileBasedAppReferenceKind.Sdk => $"{name}#sdk",
+            FileBasedAppReferenceKind.Package => $"{name}#package",
+            _ => name
+        };
 }
 
 /// <summary>

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -4,6 +4,7 @@ using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
@@ -17,18 +18,29 @@ namespace DotNetOutdated.Core.Services
         private readonly IDependencyGraphService _dependencyGraphService;
         private readonly IDotNetRestoreService _dotNetRestoreService;
         private readonly IFileSystem _fileSystem;
+        private readonly IVariableTrackingService _variableTrackingService;
         private readonly ILogger _logger;
 
-        public ProjectAnalysisService(IDependencyGraphService dependencyGraphService, IDotNetRestoreService dotNetRestoreService, IFileSystem fileSystem)
-            : this(dependencyGraphService, dotNetRestoreService, fileSystem, NullLogger.Instance)
+        public ProjectAnalysisService(
+            IDependencyGraphService dependencyGraphService,
+            IDotNetRestoreService dotNetRestoreService,
+            IFileSystem fileSystem,
+            IVariableTrackingService variableTrackingService)
+            : this(dependencyGraphService, dotNetRestoreService, fileSystem, variableTrackingService, NullLogger.Instance)
         {
         }
 
-        public ProjectAnalysisService(IDependencyGraphService dependencyGraphService, IDotNetRestoreService dotNetRestoreService, IFileSystem fileSystem, ILogger logger)
+        public ProjectAnalysisService(
+            IDependencyGraphService dependencyGraphService,
+            IDotNetRestoreService dotNetRestoreService,
+            IFileSystem fileSystem,
+            IVariableTrackingService variableTrackingService,
+            ILogger logger)
         {
             _dependencyGraphService = dependencyGraphService;
             _dotNetRestoreService = dotNetRestoreService;
             _fileSystem = fileSystem;
+            _variableTrackingService = variableTrackingService;
             _logger = logger;
         }
 
@@ -94,11 +106,51 @@ namespace DotNetOutdated.Core.Services
                             if (includeTransitiveDependencies)
                                 AddDependencies(targetFramework, projectLibrary, target, 1, transitiveDepth);
                         }
+
+                        if (isFileBasedApp)
+                        {
+                            ApplyFileBasedAppDirectives(projectPath, targetFramework);
+                        }
                     }
                 }
             }
 
             return projects;
+        }
+
+        private void ApplyFileBasedAppDirectives(string projectPath, TargetFramework targetFramework)
+        {
+            var fileBasedReferences = _variableTrackingService.DiscoverFileBasedAppReferences(projectPath);
+            if (fileBasedReferences.Count == 0)
+            {
+                return;
+            }
+
+            var authoritativeNames = new HashSet<string>(
+                fileBasedReferences.Select(reference => reference.Name),
+                StringComparer.OrdinalIgnoreCase);
+
+            var graphOnlyDependencies = targetFramework.Dependencies
+                .Where(pair => !pair.Value.IsTransitive)
+                .Select(pair => pair.Key)
+                .Where(name => !authoritativeNames.Contains(name))
+                .ToList();
+
+            foreach (var dependencyName in graphOnlyDependencies)
+            {
+                targetFramework.Dependencies.Remove(dependencyName);
+            }
+
+            foreach (var reference in fileBasedReferences)
+            {
+                targetFramework.Dependencies[reference.Name] = new Dependency(
+                    reference.Name,
+                    reference.VersionRange,
+                    reference.ResolvedVersion,
+                    isAutoReferenced: false,
+                    isTransitive: false,
+                    isDevelopmentDependency: false);
+            }
         }
 
         private void AddDependencies(TargetFramework targetFramework, LockFileTargetLibrary parentLibrary, LockFileTarget target, int level, int transitiveDepth)

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -126,7 +126,9 @@ namespace DotNetOutdated.Core.Services
 
                         if (isFileBasedApp)
                         {
-                            ApplyFileBasedAppDirectives(projectPath, targetFramework);
+                            // Use the normalized full path so directive discovery (and its cache) keys off the
+                            // same path used for restore and asset loading, even when the caller passed a relative path.
+                            ApplyFileBasedAppDirectives(analyzedProjectPath, targetFramework);
                         }
                     }
                 }

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -24,6 +24,23 @@ namespace DotNetOutdated.Core.Services
         public ProjectAnalysisService(
             IDependencyGraphService dependencyGraphService,
             IDotNetRestoreService dotNetRestoreService,
+            IFileSystem fileSystem)
+            : this(dependencyGraphService, dotNetRestoreService, fileSystem, new VariableTrackingService(fileSystem))
+        {
+        }
+
+        public ProjectAnalysisService(
+            IDependencyGraphService dependencyGraphService,
+            IDotNetRestoreService dotNetRestoreService,
+            IFileSystem fileSystem,
+            ILogger logger)
+            : this(dependencyGraphService, dotNetRestoreService, fileSystem, new VariableTrackingService(fileSystem), logger)
+        {
+        }
+
+        public ProjectAnalysisService(
+            IDependencyGraphService dependencyGraphService,
+            IDotNetRestoreService dotNetRestoreService,
             IFileSystem fileSystem,
             IVariableTrackingService variableTrackingService)
             : this(dependencyGraphService, dotNetRestoreService, fileSystem, variableTrackingService, NullLogger.Instance)

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -143,16 +143,16 @@ namespace DotNetOutdated.Core.Services
                 return;
             }
 
-            var authoritativeNames = new HashSet<string>(
-                fileBasedReferences.Select(reference => reference.Name),
-                StringComparer.OrdinalIgnoreCase);
-
-            var graphOnlyDependencyKeys = targetFramework.Dependencies
-                .Where(pair => !pair.Value.IsTransitive && !authoritativeNames.Contains(pair.Value.Name))
+            // The directives are the authoritative source of direct dependencies for a file-based app.
+            // Remove every non-transitive graph dependency (including graph entries for packages that are
+            // also declared as directives) and re-add the directive references below. Re-adding under the
+            // directive keys would otherwise leave a duplicate graph entry keyed by the plain package name.
+            var directDependencyKeys = targetFramework.Dependencies
+                .Where(pair => !pair.Value.IsTransitive)
                 .Select(pair => pair.Key)
                 .ToList();
 
-            foreach (var dependencyKey in graphOnlyDependencyKeys)
+            foreach (var dependencyKey in directDependencyKeys)
             {
                 targetFramework.Dependencies.Remove(dependencyKey);
             }

--- a/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
+++ b/src/DotNetOutdated.Core/Services/ProjectAnalysisService.cs
@@ -147,20 +147,19 @@ namespace DotNetOutdated.Core.Services
                 fileBasedReferences.Select(reference => reference.Name),
                 StringComparer.OrdinalIgnoreCase);
 
-            var graphOnlyDependencies = targetFramework.Dependencies
-                .Where(pair => !pair.Value.IsTransitive)
+            var graphOnlyDependencyKeys = targetFramework.Dependencies
+                .Where(pair => !pair.Value.IsTransitive && !authoritativeNames.Contains(pair.Value.Name))
                 .Select(pair => pair.Key)
-                .Where(name => !authoritativeNames.Contains(name))
                 .ToList();
 
-            foreach (var dependencyName in graphOnlyDependencies)
+            foreach (var dependencyKey in graphOnlyDependencyKeys)
             {
-                targetFramework.Dependencies.Remove(dependencyName);
+                targetFramework.Dependencies.Remove(dependencyKey);
             }
 
             foreach (var reference in fileBasedReferences)
             {
-                targetFramework.Dependencies[reference.Name] = new Dependency(
+                targetFramework.Dependencies[FileBasedAppReferenceHelper.GetDependencyDictionaryKey(reference)] = new Dependency(
                     reference.Name,
                     reference.VersionRange,
                     reference.ResolvedVersion,

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.Regexes.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.Regexes.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+
+namespace DotNetOutdated.Core.Services;
+
+public sealed partial class VariableTrackingService
+{
+    [GeneratedRegex(@"^[ \t]*#:[ \t]*package[ \t]+(.+?)\s*$")]
+    private static partial Regex PackageDirectiveLineRegex();
+
+    [GeneratedRegex(@"^[ \t]*#:[ \t]*sdk[ \t]+(.+?)\s*$")]
+    private static partial Regex SdkDirectiveLineRegex();
+
+    [GeneratedRegex(@"^[ \t]*#:[ \t]*property[ \t]+([^=\s]+)[ \t]*=[ \t]*(.*?)\s*$")]
+    private static partial Regex PropertyDirectiveLineRegex();
+
+    [GeneratedRegex(@"\$\(([^)]+)\)")]
+    private static partial Regex MsBuildPropertyReferenceRegex();
+
+    [GeneratedRegex(@"(^[ \t]*#:[ \t]*package[ \t]+)([^\r\n]*)(\r?\n|$)", RegexOptions.Multiline)]
+    private static partial Regex PackageDirectiveReplaceRegex();
+
+    [GeneratedRegex(@"(^[ \t]*#:[ \t]*sdk[ \t]+)([^\r\n]*)(\r?\n|$)", RegexOptions.Multiline)]
+    private static partial Regex SdkDirectiveReplaceRegex();
+}

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -265,7 +265,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
                     propertyContent,
                     propertyPattern,
                     match => match.Groups[1].Value + newVersion + match.Groups[3].Value,
-                    RegexOptions.Multiline);
+                    RegexOptions.Multiline | RegexOptions.IgnoreCase);
                 if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
                 {
                     _fileSystem.File.WriteAllText(variableInfo.FilePath, newPropertyContent);
@@ -344,7 +344,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
                     propertyContent,
                     propertyPattern,
                     match => match.Groups[1].Value + newVersion + match.Groups[3].Value,
-                    RegexOptions.Multiline);
+                    RegexOptions.Multiline | RegexOptions.IgnoreCase);
                 if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
                 {
                     _fileSystem.File.WriteAllText(variableInfo.FilePath, newPropertyContent);
@@ -824,16 +824,28 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
 
     private static bool TryParsePackageDirective(string directive, out string packageExpression, out string versionExpression)
     {
-        var separatorIndex = directive.LastIndexOf('@');
-        if (separatorIndex <= 0 || separatorIndex == directive.Length - 1)
+        packageExpression = string.Empty;
+        versionExpression = string.Empty;
+
+        // The directive value is the first whitespace-delimited token (name@version). Neither a package id,
+        // an SDK id, a version, nor an MSBuild property reference contains whitespace, so anything after the
+        // first space/tab (for example an inline `// pinned` comment) is trailing content that must be ignored.
+        // This mirrors UpdateFileBasedAppDirectReference, which preserves such trailing content during upgrades.
+        var token = directive.Trim();
+        var whitespaceIndex = token.IndexOfAny([' ', '\t']);
+        if (whitespaceIndex >= 0)
         {
-            packageExpression = string.Empty;
-            versionExpression = string.Empty;
+            token = token[..whitespaceIndex];
+        }
+
+        var separatorIndex = token.LastIndexOf('@');
+        if (separatorIndex <= 0 || separatorIndex == token.Length - 1)
+        {
             return false;
         }
 
-        packageExpression = directive[..separatorIndex].Trim();
-        versionExpression = directive[(separatorIndex + 1)..].Trim();
+        packageExpression = token[..separatorIndex].Trim();
+        versionExpression = token[(separatorIndex + 1)..].Trim();
         return !string.IsNullOrEmpty(packageExpression) && !string.IsNullOrEmpty(versionExpression);
     }
 

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -22,7 +22,19 @@ public interface IVariableTrackingService
     /// </summary>
     /// <param name="variableInfo">Information about the package variable to update</param>
     /// <param name="newVersion">The new version to set</param>
-    void UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion);
+    /// <returns><see langword="true"/> when at least one file was updated; otherwise <see langword="false"/>.</returns>
+    bool UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion);
+
+    /// <summary>
+    /// Updates a literal <c>#:package</c> or <c>#:sdk</c> directive in a file-based app source file.
+    /// </summary>
+    /// <returns><see langword="true"/> when the directive line was updated; otherwise <see langword="false"/>.</returns>
+    bool UpdateFileBasedAppDirectReference(string projectFilePath, string name, FileBasedAppReferenceKind kind, NuGetVersion newVersion);
+
+    /// <summary>
+    /// Discovers <c>#:package</c> and <c>#:sdk</c> references declared in a file-based app, including literal and variable-backed versions.
+    /// </summary>
+    IReadOnlyList<FileBasedAppReference> DiscoverFileBasedAppReferences(string projectFilePath);
 
     /// <summary>
     /// Clears the internal cache. Useful for testing or when you know files have changed.
@@ -34,7 +46,7 @@ public interface IVariableTrackingService
 // and restores those variable references after dotnet add package overwrites them with literals.
 // Uses a hybrid approach: XDocument to locate values, regex to update files while preserving formatting.
 // Limitations: no second-order variable resolution, no conditional property handling.
-public sealed class VariableTrackingService : IVariableTrackingService
+public sealed partial class VariableTrackingService : IVariableTrackingService
 {
     private readonly IFileSystem _fileSystem;
     private readonly Action<string> _onWarning;
@@ -52,16 +64,33 @@ public sealed class VariableTrackingService : IVariableTrackingService
         _cache.Clear();
     }
 
-    public void UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
+    public bool UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
     {
         try
         {
             if (variableInfo.ElementType == PackageVariableInfo.FileBasedPackageDirectiveElementType)
             {
-                UpdateFileBasedAppPackageVariable(variableInfo, newVersion);
-                InvalidateCache(variableInfo.FilePath, variableInfo.PackageReferenceFilePath);
-                return;
+                var updated = UpdateFileBasedAppPackageVariable(variableInfo, newVersion);
+                if (updated)
+                {
+                    InvalidateCache(variableInfo.FilePath, variableInfo.PackageReferenceFilePath);
+                }
+
+                return updated;
             }
+
+            if (variableInfo.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType)
+            {
+                var updated = UpdateFileBasedAppSdkVariable(variableInfo, newVersion);
+                if (updated)
+                {
+                    InvalidateCache(variableInfo.FilePath, variableInfo.PackageReferenceFilePath);
+                }
+
+                return updated;
+            }
+
+            var msbuildUpdated = false;
 
             // Step 1: Update the property value in the file where it's defined
             string propertyFilePath = variableInfo.FilePath;
@@ -80,8 +109,12 @@ public sealed class VariableTrackingService : IVariableTrackingService
                     string oldValue = propertyElement.Value;
                     string pattern = $@"<{Regex.Escape(variableInfo.VariableName)}>{Regex.Escape(oldValue)}</{Regex.Escape(variableInfo.VariableName)}>";
                     string replacement = $"<{variableInfo.VariableName}>{newVersion}</{variableInfo.VariableName}>";
-                    propertyContent = Regex.Replace(propertyContent, pattern, replacement);
-                    _fileSystem.File.WriteAllText(propertyFilePath, propertyContent);
+                    var newPropertyContent = Regex.Replace(propertyContent, pattern, replacement);
+                    if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
+                    {
+                        _fileSystem.File.WriteAllText(propertyFilePath, newPropertyContent);
+                        msbuildUpdated = true;
+                    }
                 }
             }
 
@@ -114,30 +147,131 @@ public sealed class VariableTrackingService : IVariableTrackingService
                 }
 
                 _fileSystem.File.WriteAllText(packageRefFilePath, packageRefContent);
+                msbuildUpdated = true;
             }
 
-            InvalidateCache(propertyFilePath, packageRefFilePath);
+            if (msbuildUpdated)
+            {
+                InvalidateCache(propertyFilePath, packageRefFilePath);
+            }
+
+            return msbuildUpdated;
         }
         catch (Exception ex)
         {
             _onWarning?.Invoke($"Failed to preserve variable reference for '{variableInfo.PackageName}': {ex.Message}");
+            return false;
         }
     }
 
-    private void UpdateFileBasedAppPackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
+    public bool UpdateFileBasedAppDirectReference(string projectFilePath, string name, FileBasedAppReferenceKind kind, NuGetVersion newVersion)
     {
-        if (_fileSystem.File.Exists(variableInfo.FilePath))
+        if (!projectFilePath.IsCSharpFile() || !_fileSystem.File.Exists(projectFilePath))
+        {
+            return false;
+        }
+
+        var directiveName = kind == FileBasedAppReferenceKind.Sdk ? "sdk" : "package";
+        var content = _fileSystem.File.ReadAllText(projectFilePath);
+        var updatedContent = Regex.Replace(
+            content,
+            $@"(^[ \t]*#:[ \t]*{directiveName}[ \t]+){Regex.Escape(name)}@[^\r\n]*(\r?\n|$)",
+            match => $"{match.Groups[1].Value}{name}@{newVersion}{match.Groups[2].Value}",
+            RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+        if (string.Equals(content, updatedContent, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        _fileSystem.File.WriteAllText(projectFilePath, updatedContent);
+        InvalidateCache(projectFilePath, projectFilePath);
+        return true;
+    }
+
+    public IReadOnlyList<FileBasedAppReference> DiscoverFileBasedAppReferences(string projectFilePath)
+    {
+        var references = new List<FileBasedAppReference>();
+        if (!projectFilePath.IsCSharpFile() || !_fileSystem.File.Exists(projectFilePath))
+        {
+            return references;
+        }
+
+        var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
+        CollectFileBasedAppPropertyDefinitions(projectFilePath, propertyDefinitions);
+
+        foreach (var line in _fileSystem.File.ReadLines(projectFilePath))
+        {
+            var packageMatch = PackageDirectiveLineRegex().Match(line);
+            if (packageMatch.Success &&
+                TryCreateFileBasedAppReference(packageMatch.Groups[1].Value, propertyDefinitions, FileBasedAppReferenceKind.Package, null, out var packageReference))
+            {
+                references.Add(packageReference);
+                continue;
+            }
+
+            var sdkMatch = SdkDirectiveLineRegex().Match(line);
+            if (sdkMatch.Success &&
+                TryCreateFileBasedAppReference(sdkMatch.Groups[1].Value, propertyDefinitions, FileBasedAppReferenceKind.Sdk, null, out var sdkReference))
+            {
+                references.Add(sdkReference);
+            }
+        }
+
+        foreach (var variableInfo in DiscoverPackageVariables(projectFilePath).Values)
+        {
+            if (variableInfo.ElementType != PackageVariableInfo.FileBasedPackageDirectiveElementType &&
+                variableInfo.ElementType != PackageVariableInfo.FileBasedSdkDirectiveElementType)
+            {
+                continue;
+            }
+
+            if (!NuGetVersion.TryParse(variableInfo.VariableValue, out var resolvedVersion))
+            {
+                continue;
+            }
+
+            references.Add(new FileBasedAppReference
+            {
+                Name = variableInfo.PackageName,
+                ResolvedVersion = resolvedVersion,
+                VersionRange = new VersionRange(resolvedVersion),
+                Kind = variableInfo.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType
+                    ? FileBasedAppReferenceKind.Sdk
+                    : FileBasedAppReferenceKind.Package,
+                NameExpression = variableInfo.PackageReferenceName,
+                VersionExpression = variableInfo.PackageReferenceVersion,
+                VariableInfo = variableInfo
+            });
+        }
+
+        return [
+            .. references
+                .GroupBy(reference => reference.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.FirstOrDefault(reference => reference.VariableInfo != null) ?? group.First())
+        ];
+    }
+
+    private bool UpdateFileBasedAppSdkVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
+    {
+        var updated = false;
+
+        if (_fileSystem.File.Exists(variableInfo.FilePath) && !string.IsNullOrEmpty(variableInfo.VariableName))
         {
             if (variableInfo.FilePath.IsCSharpFile())
             {
                 var propertyContent = _fileSystem.File.ReadAllText(variableInfo.FilePath);
                 var propertyPattern = $@"(^[ \t]*#:[ \t]*property[ \t]+{Regex.Escape(variableInfo.VariableName)}[ \t]*=[ \t]*)([^\r\n]*)(\r?\n|$)";
-                propertyContent = Regex.Replace(
+                var newPropertyContent = Regex.Replace(
                     propertyContent,
                     propertyPattern,
                     match => match.Groups[1].Value + newVersion + match.Groups[3].Value,
                     RegexOptions.Multiline);
-                _fileSystem.File.WriteAllText(variableInfo.FilePath, propertyContent);
+                if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
+                {
+                    _fileSystem.File.WriteAllText(variableInfo.FilePath, newPropertyContent);
+                    updated = true;
+                }
             }
             else
             {
@@ -152,8 +286,91 @@ public sealed class VariableTrackingService : IVariableTrackingService
                     string oldValue = propertyElement.Value;
                     string pattern = $@"<{Regex.Escape(variableInfo.VariableName)}>{Regex.Escape(oldValue)}</{Regex.Escape(variableInfo.VariableName)}>";
                     string replacement = $"<{variableInfo.VariableName}>{newVersion}</{variableInfo.VariableName}>";
-                    propertyContent = Regex.Replace(propertyContent, pattern, replacement);
-                    _fileSystem.File.WriteAllText(variableInfo.FilePath, propertyContent);
+                    var newPropertyContent = Regex.Replace(propertyContent, pattern, replacement);
+                    if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
+                    {
+                        _fileSystem.File.WriteAllText(variableInfo.FilePath, newPropertyContent);
+                        updated = true;
+                    }
+                }
+            }
+        }
+
+        if (_fileSystem.File.Exists(variableInfo.PackageReferenceFilePath) && variableInfo.PackageReferenceFilePath.IsCSharpFile())
+        {
+            var sdkContent = _fileSystem.File.ReadAllText(variableInfo.PackageReferenceFilePath);
+            var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
+            CollectFileBasedAppPropertyDefinitions(variableInfo.PackageReferenceFilePath, propertyDefinitions);
+            var directiveVersion = FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(variableInfo.PackageReferenceVersion)
+                ? variableInfo.PackageReferenceVersion
+                : newVersion.ToString();
+
+            var newSdkContent = SdkDirectiveReplaceRegex().Replace(
+                sdkContent,
+                match =>
+                {
+                    var sdkDirective = match.Groups[2].Value;
+                    if (!TryParsePackageDirective(sdkDirective, out var sdkExpression, out _) ||
+                        (!string.Equals(sdkExpression, variableInfo.PackageReferenceName, StringComparison.OrdinalIgnoreCase) &&
+                         (!TryResolveProperties(sdkExpression, propertyDefinitions, out var sdkName) ||
+                          !string.Equals(sdkName, variableInfo.PackageName, StringComparison.OrdinalIgnoreCase))))
+                    {
+                        return match.Value;
+                    }
+
+                    return match.Groups[1].Value + variableInfo.PackageReferenceName + "@" + directiveVersion + match.Groups[3].Value;
+                });
+
+            if (!string.Equals(sdkContent, newSdkContent, StringComparison.Ordinal))
+            {
+                _fileSystem.File.WriteAllText(variableInfo.PackageReferenceFilePath, newSdkContent);
+                updated = true;
+            }
+        }
+
+        return updated;
+    }
+
+    private bool UpdateFileBasedAppPackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
+    {
+        var updated = false;
+
+        if (_fileSystem.File.Exists(variableInfo.FilePath))
+        {
+            if (variableInfo.FilePath.IsCSharpFile())
+            {
+                var propertyContent = _fileSystem.File.ReadAllText(variableInfo.FilePath);
+                var propertyPattern = $@"(^[ \t]*#:[ \t]*property[ \t]+{Regex.Escape(variableInfo.VariableName)}[ \t]*=[ \t]*)([^\r\n]*)(\r?\n|$)";
+                var newPropertyContent = Regex.Replace(
+                    propertyContent,
+                    propertyPattern,
+                    match => match.Groups[1].Value + newVersion + match.Groups[3].Value,
+                    RegexOptions.Multiline);
+                if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
+                {
+                    _fileSystem.File.WriteAllText(variableInfo.FilePath, newPropertyContent);
+                    updated = true;
+                }
+            }
+            else
+            {
+                var propertyContent = _fileSystem.File.ReadAllText(variableInfo.FilePath);
+                var propertyDoc = XDocument.Parse(propertyContent);
+                var propertyElement = propertyDoc.Descendants()
+                    .FirstOrDefault(e => e.Name.LocalName == variableInfo.VariableName &&
+                                         e.Parent?.Name.LocalName == "PropertyGroup");
+
+                if (propertyElement != null)
+                {
+                    string oldValue = propertyElement.Value;
+                    string pattern = $@"<{Regex.Escape(variableInfo.VariableName)}>{Regex.Escape(oldValue)}</{Regex.Escape(variableInfo.VariableName)}>";
+                    string replacement = $"<{variableInfo.VariableName}>{newVersion}</{variableInfo.VariableName}>";
+                    var newPropertyContent = Regex.Replace(propertyContent, pattern, replacement);
+                    if (!string.Equals(propertyContent, newPropertyContent, StringComparison.Ordinal))
+                    {
+                        _fileSystem.File.WriteAllText(variableInfo.FilePath, newPropertyContent);
+                        updated = true;
+                    }
                 }
             }
         }
@@ -163,10 +380,12 @@ public sealed class VariableTrackingService : IVariableTrackingService
             var packageContent = _fileSystem.File.ReadAllText(variableInfo.PackageReferenceFilePath);
             var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
             CollectFileBasedAppPropertyDefinitions(variableInfo.PackageReferenceFilePath, propertyDefinitions);
+            var directiveVersion = FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(variableInfo.PackageReferenceVersion)
+                ? variableInfo.PackageReferenceVersion
+                : newVersion.ToString();
 
-            packageContent = Regex.Replace(
+            var newPackageContent = PackageDirectiveReplaceRegex().Replace(
                 packageContent,
-                @"(^[ \t]*#:[ \t]*package[ \t]+)([^\r\n]*)(\r?\n|$)",
                 match =>
                 {
                     var packageDirective = match.Groups[2].Value;
@@ -178,12 +397,17 @@ public sealed class VariableTrackingService : IVariableTrackingService
                         return match.Value;
                     }
 
-                    return match.Groups[1].Value + variableInfo.PackageReferenceName + "@" + variableInfo.PackageReferenceVersion + match.Groups[3].Value;
-                },
-                RegexOptions.Multiline);
+                    return match.Groups[1].Value + variableInfo.PackageReferenceName + "@" + directiveVersion + match.Groups[3].Value;
+                });
 
-            _fileSystem.File.WriteAllText(variableInfo.PackageReferenceFilePath, packageContent);
+            if (!string.Equals(packageContent, newPackageContent, StringComparison.Ordinal))
+            {
+                _fileSystem.File.WriteAllText(variableInfo.PackageReferenceFilePath, newPackageContent);
+                updated = true;
+            }
         }
+
+        return updated;
     }
 
     private void InvalidateCache(string propertyFilePath, string packageRefFilePath)
@@ -266,6 +490,7 @@ public sealed class VariableTrackingService : IVariableTrackingService
         if (isFileBasedApp)
         {
             ScanFileBasedAppForVariables(projectFilePath, result, propertyDefinitions);
+            ScanFileBasedAppForSdkVariables(projectFilePath, result, propertyDefinitions);
         }
 
         // Now scan all files for package references that use variables
@@ -313,7 +538,7 @@ public sealed class VariableTrackingService : IVariableTrackingService
     {
         foreach (var line in _fileSystem.File.ReadLines(filePath))
         {
-            var match = Regex.Match(line, @"^[ \t]*#:[ \t]*property[ \t]+([^=\s]+)[ \t]*=[ \t]*(.*?)\s*$");
+            var match = PropertyDirectiveLineRegex().Match(line);
             if (!match.Success)
             {
                 continue;
@@ -350,7 +575,7 @@ public sealed class VariableTrackingService : IVariableTrackingService
                     continue;
 
                 // Check if version uses a variable reference like $(VariableName)
-                var match = Regex.Match(versionValue, @"\$\(([^)]+)\)");
+                var match = MsBuildPropertyReferenceRegex().Match(versionValue);
                 if (match.Success)
                 {
                     string variableName = match.Groups[1].Value;
@@ -381,7 +606,7 @@ public sealed class VariableTrackingService : IVariableTrackingService
     {
         foreach (var line in _fileSystem.File.ReadLines(filePath))
         {
-            var match = Regex.Match(line, @"^[ \t]*#:[ \t]*package[ \t]+(.+?)\s*$");
+            var match = PackageDirectiveLineRegex().Match(line);
             if (!match.Success)
             {
                 continue;
@@ -394,7 +619,7 @@ public sealed class VariableTrackingService : IVariableTrackingService
                 continue;
             }
 
-            var versionMatch = Regex.Match(versionExpression, @"\$\(([^)]+)\)");
+            var versionMatch = MsBuildPropertyReferenceRegex().Match(versionExpression);
             if (!versionMatch.Success)
             {
                 continue;
@@ -418,6 +643,92 @@ public sealed class VariableTrackingService : IVariableTrackingService
         }
     }
 
+    private void ScanFileBasedAppForSdkVariables(string filePath, Dictionary<string, PackageVariableInfo> result, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    {
+        foreach (var line in _fileSystem.File.ReadLines(filePath))
+        {
+            var match = SdkDirectiveLineRegex().Match(line);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            if (!TryParsePackageDirective(match.Groups[1].Value, out var sdkExpression, out var versionExpression) ||
+                !TryResolveProperties(sdkExpression, propertyDefinitions, out var sdkName) ||
+                result.ContainsKey(sdkName))
+            {
+                continue;
+            }
+
+            var versionMatch = MsBuildPropertyReferenceRegex().Match(versionExpression);
+            if (versionMatch.Success)
+            {
+                string variableName = versionMatch.Groups[1].Value;
+                if (propertyDefinitions.TryGetValue(variableName, out var propertyInfo))
+                {
+                    result[sdkName] = new PackageVariableInfo
+                    {
+                        PackageName = sdkName,
+                        VariableName = variableName,
+                        VariableValue = propertyInfo.Value,
+                        FilePath = propertyInfo.FilePath,
+                        PackageReferenceFilePath = filePath,
+                        ElementType = PackageVariableInfo.FileBasedSdkDirectiveElementType,
+                        PackageReferenceName = sdkExpression,
+                        PackageReferenceVersion = versionExpression
+                    };
+                }
+
+                continue;
+            }
+
+            if (FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(sdkExpression) &&
+                NuGetVersion.TryParse(versionExpression, out _))
+            {
+                result[sdkName] = new PackageVariableInfo
+                {
+                    PackageName = sdkName,
+                    VariableName = string.Empty,
+                    VariableValue = versionExpression,
+                    FilePath = filePath,
+                    PackageReferenceFilePath = filePath,
+                    ElementType = PackageVariableInfo.FileBasedSdkDirectiveElementType,
+                    PackageReferenceName = sdkExpression,
+                    PackageReferenceVersion = versionExpression
+                };
+            }
+        }
+    }
+
+    private static bool TryCreateFileBasedAppReference(
+        string directive,
+        Dictionary<string, (string Value, string FilePath)> propertyDefinitions,
+        FileBasedAppReferenceKind kind,
+        PackageVariableInfo variableInfo,
+        out FileBasedAppReference reference)
+    {
+        reference = null;
+        if (!TryParsePackageDirective(directive, out var nameExpression, out var versionExpression) ||
+            !TryResolveProperties(nameExpression, propertyDefinitions, out var name) ||
+            !TryResolveProperties(versionExpression, propertyDefinitions, out var versionString) ||
+            !NuGetVersion.TryParse(versionString, out var resolvedVersion))
+        {
+            return false;
+        }
+
+        reference = new FileBasedAppReference
+        {
+            Name = name,
+            ResolvedVersion = resolvedVersion,
+            VersionRange = new VersionRange(resolvedVersion),
+            Kind = kind,
+            NameExpression = nameExpression,
+            VersionExpression = versionExpression,
+            VariableInfo = variableInfo
+        };
+        return true;
+    }
+
     private static bool TryParsePackageDirective(string directive, out string packageExpression, out string versionExpression)
     {
         var separatorIndex = directive.LastIndexOf('@');
@@ -436,7 +747,7 @@ public sealed class VariableTrackingService : IVariableTrackingService
     private static bool TryResolveProperties(string expression, Dictionary<string, (string Value, string FilePath)> propertyDefinitions, out string resolvedValue)
     {
         var unresolved = false;
-        resolvedValue = Regex.Replace(expression, @"\$\(([^)]+)\)", match =>
+        resolvedValue = MsBuildPropertyReferenceRegex().Replace(expression, match =>
         {
             if (propertyDefinitions.TryGetValue(match.Groups[1].Value, out var propertyInfo))
             {
@@ -454,6 +765,8 @@ public sealed class VariableTrackingService : IVariableTrackingService
 public class PackageVariableInfo
 {
     public const string FileBasedPackageDirectiveElementType = "FileBasedPackageDirective";
+
+    public const string FileBasedSdkDirectiveElementType = "FileBasedSdkDirective";
 
     public string PackageName { get; set; }
     public string VariableName { get; set; }

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -234,7 +234,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
             {
                 Name = variableInfo.PackageName,
                 ResolvedVersion = resolvedVersion,
-                VersionRange = FileBasedAppReferenceHelper.CreateExactVersionRange(resolvedVersion),
+                VersionRange = FileBasedAppReferenceHelper.CreateMinimumVersionRange(resolvedVersion),
                 Kind = variableInfo.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType
                     ? FileBasedAppReferenceKind.Sdk
                     : FileBasedAppReferenceKind.Package,
@@ -813,7 +813,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         {
             Name = name,
             ResolvedVersion = resolvedVersion,
-            VersionRange = FileBasedAppReferenceHelper.CreateExactVersionRange(resolvedVersion),
+            VersionRange = FileBasedAppReferenceHelper.CreateMinimumVersionRange(resolvedVersion),
             Kind = kind,
             NameExpression = nameExpression,
             VersionExpression = versionExpression,

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -224,7 +224,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
             {
                 Name = variableInfo.PackageName,
                 ResolvedVersion = resolvedVersion,
-                VersionRange = new VersionRange(resolvedVersion),
+                VersionRange = FileBasedAppReferenceHelper.CreateExactVersionRange(resolvedVersion),
                 Kind = variableInfo.ElementType == PackageVariableInfo.FileBasedSdkDirectiveElementType
                     ? FileBasedAppReferenceKind.Sdk
                     : FileBasedAppReferenceKind.Package,
@@ -539,10 +539,14 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
             directory = directory.Parent;
         }
 
-        foreach (var line in _fileSystem.File.ReadLines(projectFilePath))
+        var lines = _fileSystem.File.ReadLines(projectFilePath).ToList();
+        foreach (var line in lines)
         {
             CollectFileBasedAppPropertyFromLine(line, projectFilePath, propertyDefinitions);
+        }
 
+        foreach (var line in lines)
+        {
             var packageMatch = PackageDirectiveLineRegex().Match(line);
             if (packageMatch.Success)
             {
@@ -608,7 +612,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
     {
         using var reader = new StringReader(content);
-        string? line;
+        string line;
         while ((line = reader.ReadLine()) != null)
         {
             CollectFileBasedAppPropertyFromLine(line, filePath, propertyDefinitions);
@@ -788,7 +792,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         PackageVariableInfo variableInfo,
         out FileBasedAppReference reference)
     {
-        reference = null;
+        reference = null!;
         if (!TryParsePackageDirective(directive, out var nameExpression, out var versionExpression) ||
             !TryResolveProperties(nameExpression, propertyDefinitions, out var name) ||
             !TryResolveProperties(versionExpression, propertyDefinitions, out var versionString) ||
@@ -801,7 +805,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         {
             Name = name,
             ResolvedVersion = resolvedVersion,
-            VersionRange = new VersionRange(resolvedVersion),
+            VersionRange = FileBasedAppReferenceHelper.CreateExactVersionRange(resolvedVersion),
             Kind = kind,
             NameExpression = nameExpression,
             VersionExpression = versionExpression,

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -236,7 +236,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
 
         return [
             .. references
-                .GroupBy(reference => reference.Name, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(reference => (reference.Kind, Name: reference.Name.ToUpperInvariant()))
                 .Select(group => group.FirstOrDefault(reference => reference.VariableInfo != null) ?? group.First())
         ];
     }

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -51,17 +51,20 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
     private readonly IFileSystem _fileSystem;
     private readonly Action<string> _onWarning;
     private readonly Dictionary<string, Dictionary<string, PackageVariableInfo>> _cache;
+    private readonly Dictionary<string, FileBasedAppScanResult> _fileBasedAppScanCache;
 
     public VariableTrackingService(IFileSystem fileSystem, Action<string> onWarning = null)
     {
         _fileSystem = fileSystem;
         _onWarning = onWarning;
         _cache = new Dictionary<string, Dictionary<string, PackageVariableInfo>>(StringComparer.OrdinalIgnoreCase);
+        _fileBasedAppScanCache = new Dictionary<string, FileBasedAppScanResult>(StringComparer.OrdinalIgnoreCase);
     }
 
     public void ClearCache()
     {
         _cache.Clear();
+        _fileBasedAppScanCache.Clear();
     }
 
     public bool UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
@@ -163,7 +166,8 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         }
         catch (Exception ex)
         {
-            _onWarning?.Invoke($"Failed to preserve variable reference for '{variableInfo.PackageName}': {ex.Message}");
+            _onWarning?.Invoke(
+                $"Failed to update package reference '{variableInfo.PackageName}' ({variableInfo.ElementType}): {ex.Message}");
             return false;
         }
     }
@@ -179,8 +183,8 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         var content = _fileSystem.File.ReadAllText(projectFilePath);
         var updatedContent = Regex.Replace(
             content,
-            $@"(^[ \t]*#:[ \t]*{directiveName}[ \t]+){Regex.Escape(name)}@[^\r\n]*(\r?\n|$)",
-            match => $"{match.Groups[1].Value}{name}@{newVersion}{match.Groups[2].Value}",
+            $@"(^[ \t]*#:[ \t]*{directiveName}[ \t]+{Regex.Escape(name)}@)([^\s\r\n]+)(.*?)(\r?\n|$)",
+            match => $"{match.Groups[1].Value}{newVersion}{match.Groups[3].Value}{match.Groups[4].Value}",
             RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
         if (string.Equals(content, updatedContent, StringComparison.Ordinal))
@@ -195,34 +199,15 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
 
     public IReadOnlyList<FileBasedAppReference> DiscoverFileBasedAppReferences(string projectFilePath)
     {
-        var references = new List<FileBasedAppReference>();
         if (!projectFilePath.IsCSharpFile() || !_fileSystem.File.Exists(projectFilePath))
         {
-            return references;
+            return [];
         }
 
-        var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
-        CollectFileBasedAppPropertyDefinitions(projectFilePath, propertyDefinitions);
+        var scan = GetOrScanFileBasedApp(projectFilePath);
+        var references = new List<FileBasedAppReference>(scan.LiteralReferences);
 
-        foreach (var line in _fileSystem.File.ReadLines(projectFilePath))
-        {
-            var packageMatch = PackageDirectiveLineRegex().Match(line);
-            if (packageMatch.Success &&
-                TryCreateFileBasedAppReference(packageMatch.Groups[1].Value, propertyDefinitions, FileBasedAppReferenceKind.Package, null, out var packageReference))
-            {
-                references.Add(packageReference);
-                continue;
-            }
-
-            var sdkMatch = SdkDirectiveLineRegex().Match(line);
-            if (sdkMatch.Success &&
-                TryCreateFileBasedAppReference(sdkMatch.Groups[1].Value, propertyDefinitions, FileBasedAppReferenceKind.Sdk, null, out var sdkReference))
-            {
-                references.Add(sdkReference);
-            }
-        }
-
-        foreach (var variableInfo in DiscoverPackageVariables(projectFilePath).Values)
+        foreach (var variableInfo in scan.PackageVariables.Values)
         {
             if (variableInfo.ElementType != PackageVariableInfo.FileBasedPackageDirectiveElementType &&
                 variableInfo.ElementType != PackageVariableInfo.FileBasedSdkDirectiveElementType)
@@ -304,7 +289,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         {
             var sdkContent = _fileSystem.File.ReadAllText(variableInfo.PackageReferenceFilePath);
             var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
-            CollectFileBasedAppPropertyDefinitions(variableInfo.PackageReferenceFilePath, propertyDefinitions);
+            CollectFileBasedAppPropertyDefinitionsForUpdate(variableInfo.PackageReferenceFilePath, sdkContent, propertyDefinitions);
             var directiveVersion = FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(variableInfo.PackageReferenceVersion)
                 ? variableInfo.PackageReferenceVersion
                 : newVersion.ToString();
@@ -383,7 +368,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         {
             var packageContent = _fileSystem.File.ReadAllText(variableInfo.PackageReferenceFilePath);
             var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
-            CollectFileBasedAppPropertyDefinitions(variableInfo.PackageReferenceFilePath, propertyDefinitions);
+            CollectFileBasedAppPropertyDefinitionsForUpdate(variableInfo.PackageReferenceFilePath, packageContent, propertyDefinitions);
             var directiveVersion = FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(variableInfo.PackageReferenceVersion)
                 ? variableInfo.PackageReferenceVersion
                 : newVersion.ToString();
@@ -442,6 +427,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         foreach (var key in keysToRemove)
         {
             _cache.Remove(key);
+            _fileBasedAppScanCache.Remove(key);
         }
     }
 
@@ -462,13 +448,16 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
             return result;
         }
 
+        if (projectFilePath.IsCSharpFile())
+        {
+            return GetOrScanFileBasedApp(projectFilePath).PackageVariables;
+        }
+
         // First, collect all property definitions from all relevant files
         var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
 
-        var isFileBasedApp = projectFilePath.IsCSharpFile();
-
         // Collect files to scan (project file + all .props files in parent hierarchy)
-        var filesToScan = isFileBasedApp ? new List<string>() : new List<string> { projectFilePath };
+        var filesToScan = new List<string> { projectFilePath };
         var directory = projectFile.Directory;
         while (directory != null)
         {
@@ -480,21 +469,10 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
             directory = directory.Parent;
         }
 
-        if (isFileBasedApp)
-        {
-            CollectFileBasedAppPropertyDefinitions(projectFilePath, propertyDefinitions);
-        }
-
         // Scan all files for property definitions
         foreach (var fileToScan in filesToScan)
         {
             CollectPropertyDefinitions(fileToScan, propertyDefinitions);
-        }
-
-        if (isFileBasedApp)
-        {
-            ScanFileBasedAppForVariables(projectFilePath, result, propertyDefinitions);
-            ScanFileBasedAppForSdkVariables(projectFilePath, result, propertyDefinitions);
         }
 
         // Now scan all files for package references that use variables
@@ -538,22 +516,219 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         }
     }
 
-    private void CollectFileBasedAppPropertyDefinitions(string filePath, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    private FileBasedAppScanResult GetOrScanFileBasedApp(string projectFilePath)
     {
-        foreach (var line in _fileSystem.File.ReadLines(filePath))
+        if (_fileBasedAppScanCache.TryGetValue(projectFilePath, out var cachedScan))
         {
-            var match = PropertyDirectiveLineRegex().Match(line);
-            if (!match.Success)
+            return cachedScan;
+        }
+
+        var packageVariables = new Dictionary<string, PackageVariableInfo>(StringComparer.OrdinalIgnoreCase);
+        var literalReferences = new List<FileBasedAppReference>();
+        var propertyDefinitions = new Dictionary<string, (string Value, string FilePath)>(StringComparer.OrdinalIgnoreCase);
+
+        var projectFile = _fileSystem.FileInfo.New(projectFilePath);
+        var directory = projectFile.Directory;
+        while (directory != null)
+        {
+            foreach (var propsFile in directory.GetFiles("*.props", SearchOption.TopDirectoryOnly))
             {
+                CollectPropertyDefinitions(propsFile.FullName, propertyDefinitions);
+            }
+
+            directory = directory.Parent;
+        }
+
+        foreach (var line in _fileSystem.File.ReadLines(projectFilePath))
+        {
+            CollectFileBasedAppPropertyFromLine(line, projectFilePath, propertyDefinitions);
+
+            var packageMatch = PackageDirectiveLineRegex().Match(line);
+            if (packageMatch.Success)
+            {
+                ScanFileBasedAppPackageLine(packageMatch.Groups[1].Value, projectFilePath, propertyDefinitions, packageVariables);
+                if (TryCreateFileBasedAppReference(
+                        packageMatch.Groups[1].Value,
+                        propertyDefinitions,
+                        FileBasedAppReferenceKind.Package,
+                        null,
+                        out var packageReference))
+                {
+                    literalReferences.Add(packageReference);
+                }
+
                 continue;
             }
 
-            var propertyName = match.Groups[1].Value;
-            if (!propertyDefinitions.ContainsKey(propertyName))
+            var sdkMatch = SdkDirectiveLineRegex().Match(line);
+            if (sdkMatch.Success)
             {
-                propertyDefinitions[propertyName] = (match.Groups[2].Value, filePath);
+                ScanFileBasedAppSdkLine(sdkMatch.Groups[1].Value, projectFilePath, propertyDefinitions, packageVariables);
+                if (TryCreateFileBasedAppReference(
+                        sdkMatch.Groups[1].Value,
+                        propertyDefinitions,
+                        FileBasedAppReferenceKind.Sdk,
+                        null,
+                        out var sdkReference))
+                {
+                    literalReferences.Add(sdkReference);
+                }
             }
         }
+
+        var scanResult = new FileBasedAppScanResult(packageVariables, literalReferences);
+        _fileBasedAppScanCache[projectFilePath] = scanResult;
+        _cache[projectFilePath] = packageVariables;
+        return scanResult;
+    }
+
+    private void CollectFileBasedAppPropertyDefinitionsForUpdate(
+        string projectFilePath,
+        string content,
+        Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    {
+        var projectFile = _fileSystem.FileInfo.New(projectFilePath);
+        var directory = projectFile.Directory;
+        while (directory != null)
+        {
+            foreach (var propsFile in directory.GetFiles("*.props", SearchOption.TopDirectoryOnly))
+            {
+                CollectPropertyDefinitions(propsFile.FullName, propertyDefinitions);
+            }
+
+            directory = directory.Parent;
+        }
+
+        CollectFileBasedAppPropertyDefinitionsFromContent(content, projectFilePath, propertyDefinitions);
+    }
+
+    private static void CollectFileBasedAppPropertyDefinitionsFromContent(
+        string content,
+        string filePath,
+        Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    {
+        using var reader = new StringReader(content);
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            CollectFileBasedAppPropertyFromLine(line, filePath, propertyDefinitions);
+        }
+    }
+
+    private static void CollectFileBasedAppPropertyFromLine(
+        string line,
+        string filePath,
+        Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
+    {
+        var match = PropertyDirectiveLineRegex().Match(line);
+        if (!match.Success)
+        {
+            return;
+        }
+
+        var propertyName = match.Groups[1].Value;
+        if (!propertyDefinitions.ContainsKey(propertyName))
+        {
+            propertyDefinitions[propertyName] = (match.Groups[2].Value, filePath);
+        }
+    }
+
+    private static void ScanFileBasedAppPackageLine(
+        string directive,
+        string filePath,
+        Dictionary<string, (string Value, string FilePath)> propertyDefinitions,
+        Dictionary<string, PackageVariableInfo> result)
+    {
+        if (!TryParsePackageDirective(directive, out var packageExpression, out var versionExpression) ||
+            !TryResolveProperties(packageExpression, propertyDefinitions, out var packageName) ||
+            result.ContainsKey(packageName))
+        {
+            return;
+        }
+
+        var versionMatch = MsBuildPropertyReferenceRegex().Match(versionExpression);
+        if (!versionMatch.Success || !propertyDefinitions.TryGetValue(versionMatch.Groups[1].Value, out var propertyInfo))
+        {
+            return;
+        }
+
+        result[packageName] = new PackageVariableInfo
+        {
+            PackageName = packageName,
+            VariableName = versionMatch.Groups[1].Value,
+            VariableValue = propertyInfo.Value,
+            FilePath = propertyInfo.FilePath,
+            PackageReferenceFilePath = filePath,
+            ElementType = PackageVariableInfo.FileBasedPackageDirectiveElementType,
+            PackageReferenceName = packageExpression,
+            PackageReferenceVersion = versionExpression
+        };
+    }
+
+    private static void ScanFileBasedAppSdkLine(
+        string directive,
+        string filePath,
+        Dictionary<string, (string Value, string FilePath)> propertyDefinitions,
+        Dictionary<string, PackageVariableInfo> result)
+    {
+        if (!TryParsePackageDirective(directive, out var sdkExpression, out var versionExpression) ||
+            !TryResolveProperties(sdkExpression, propertyDefinitions, out var sdkName) ||
+            result.ContainsKey(sdkName))
+        {
+            return;
+        }
+
+        var versionMatch = MsBuildPropertyReferenceRegex().Match(versionExpression);
+        if (versionMatch.Success)
+        {
+            if (propertyDefinitions.TryGetValue(versionMatch.Groups[1].Value, out var propertyInfo))
+            {
+                result[sdkName] = new PackageVariableInfo
+                {
+                    PackageName = sdkName,
+                    VariableName = versionMatch.Groups[1].Value,
+                    VariableValue = propertyInfo.Value,
+                    FilePath = propertyInfo.FilePath,
+                    PackageReferenceFilePath = filePath,
+                    ElementType = PackageVariableInfo.FileBasedSdkDirectiveElementType,
+                    PackageReferenceName = sdkExpression,
+                    PackageReferenceVersion = versionExpression
+                };
+            }
+
+            return;
+        }
+
+        if (FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(sdkExpression) &&
+            NuGetVersion.TryParse(versionExpression, out _))
+        {
+            result[sdkName] = new PackageVariableInfo
+            {
+                PackageName = sdkName,
+                VariableName = string.Empty,
+                VariableValue = versionExpression,
+                FilePath = filePath,
+                PackageReferenceFilePath = filePath,
+                ElementType = PackageVariableInfo.FileBasedSdkDirectiveElementType,
+                PackageReferenceName = sdkExpression,
+                PackageReferenceVersion = versionExpression
+            };
+        }
+    }
+
+    private sealed class FileBasedAppScanResult
+    {
+        public FileBasedAppScanResult(
+            Dictionary<string, PackageVariableInfo> packageVariables,
+            List<FileBasedAppReference> literalReferences)
+        {
+            PackageVariables = packageVariables;
+            LiteralReferences = literalReferences;
+        }
+
+        public Dictionary<string, PackageVariableInfo> PackageVariables { get; }
+
+        public List<FileBasedAppReference> LiteralReferences { get; }
     }
 
     private void ScanFileForVariables(string filePath, Dictionary<string, PackageVariableInfo> result, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
@@ -603,104 +778,6 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         catch
         {
             // Silently ignore files that can't be parsed
-        }
-    }
-
-    private void ScanFileBasedAppForVariables(string filePath, Dictionary<string, PackageVariableInfo> result, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
-    {
-        foreach (var line in _fileSystem.File.ReadLines(filePath))
-        {
-            var match = PackageDirectiveLineRegex().Match(line);
-            if (!match.Success)
-            {
-                continue;
-            }
-
-            if (!TryParsePackageDirective(match.Groups[1].Value, out var packageExpression, out var versionExpression) ||
-                !TryResolveProperties(packageExpression, propertyDefinitions, out var packageName) ||
-                result.ContainsKey(packageName))
-            {
-                continue;
-            }
-
-            var versionMatch = MsBuildPropertyReferenceRegex().Match(versionExpression);
-            if (!versionMatch.Success)
-            {
-                continue;
-            }
-
-            string variableName = versionMatch.Groups[1].Value;
-            if (propertyDefinitions.TryGetValue(variableName, out var propertyInfo))
-            {
-                result[packageName] = new PackageVariableInfo
-                {
-                    PackageName = packageName,
-                    VariableName = variableName,
-                    VariableValue = propertyInfo.Value,
-                    FilePath = propertyInfo.FilePath,
-                    PackageReferenceFilePath = filePath,
-                    ElementType = PackageVariableInfo.FileBasedPackageDirectiveElementType,
-                    PackageReferenceName = packageExpression,
-                    PackageReferenceVersion = versionExpression
-                };
-            }
-        }
-    }
-
-    private void ScanFileBasedAppForSdkVariables(string filePath, Dictionary<string, PackageVariableInfo> result, Dictionary<string, (string Value, string FilePath)> propertyDefinitions)
-    {
-        foreach (var line in _fileSystem.File.ReadLines(filePath))
-        {
-            var match = SdkDirectiveLineRegex().Match(line);
-            if (!match.Success)
-            {
-                continue;
-            }
-
-            if (!TryParsePackageDirective(match.Groups[1].Value, out var sdkExpression, out var versionExpression) ||
-                !TryResolveProperties(sdkExpression, propertyDefinitions, out var sdkName) ||
-                result.ContainsKey(sdkName))
-            {
-                continue;
-            }
-
-            var versionMatch = MsBuildPropertyReferenceRegex().Match(versionExpression);
-            if (versionMatch.Success)
-            {
-                string variableName = versionMatch.Groups[1].Value;
-                if (propertyDefinitions.TryGetValue(variableName, out var propertyInfo))
-                {
-                    result[sdkName] = new PackageVariableInfo
-                    {
-                        PackageName = sdkName,
-                        VariableName = variableName,
-                        VariableValue = propertyInfo.Value,
-                        FilePath = propertyInfo.FilePath,
-                        PackageReferenceFilePath = filePath,
-                        ElementType = PackageVariableInfo.FileBasedSdkDirectiveElementType,
-                        PackageReferenceName = sdkExpression,
-                        PackageReferenceVersion = versionExpression
-                    };
-                }
-
-                continue;
-            }
-
-            if (FileBasedAppReferenceHelper.ExpressionContainsPropertyReference(sdkExpression) &&
-                NuGetVersion.TryParse(versionExpression, out _))
-            {
-                result[sdkName] = new PackageVariableInfo
-                {
-                    PackageName = sdkName,
-                    VariableName = string.Empty,
-                    VariableValue = versionExpression,
-                    FilePath = filePath,
-                    PackageReferenceFilePath = filePath,
-                    ElementType = PackageVariableInfo.FileBasedSdkDirectiveElementType,
-                    PackageReferenceName = sdkExpression,
-                    PackageReferenceVersion = versionExpression
-                };
-            }
         }
     }
 

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -131,6 +131,7 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
                                 e.Attribute("Update")?.Value.Equals(variableInfo.PackageName, StringComparison.OrdinalIgnoreCase) == true))
                     .ToList();
 
+                var newPackageRefContent = packageRefContent;
                 foreach (var packageElement in packageElements)
                 {
                     var versionAttr = packageElement.Attribute("Version");
@@ -142,12 +143,15 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
                         // Use regex to replace only the Version attribute value for this specific package
                         string packagePattern = $@"(<{Regex.Escape(variableInfo.ElementType)}\s+(?:Include|Update)=""{Regex.Escape(variableInfo.PackageName)}""\s+Version="")[^""]*("")";
                         string packageReplacement = $"$1{variableReference}$2";
-                        packageRefContent = Regex.Replace(packageRefContent, packagePattern, packageReplacement, RegexOptions.IgnoreCase);
+                        newPackageRefContent = Regex.Replace(newPackageRefContent, packagePattern, packageReplacement, RegexOptions.IgnoreCase);
                     }
                 }
 
-                _fileSystem.File.WriteAllText(packageRefFilePath, packageRefContent);
-                msbuildUpdated = true;
+                if (!string.Equals(packageRefContent, newPackageRefContent, StringComparison.Ordinal))
+                {
+                    _fileSystem.File.WriteAllText(packageRefFilePath, newPackageRefContent);
+                    msbuildUpdated = true;
+                }
             }
 
             if (msbuildUpdated)

--- a/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
+++ b/src/DotNetOutdated.Core/Services/VariableTrackingService.cs
@@ -22,8 +22,15 @@ public interface IVariableTrackingService
     /// </summary>
     /// <param name="variableInfo">Information about the package variable to update</param>
     /// <param name="newVersion">The new version to set</param>
+    void UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion);
+
+    /// <summary>
+    /// Attempts to update a package's variable value and restore the variable reference after dotnet add package overwrites it.
+    /// </summary>
+    /// <param name="variableInfo">Information about the package variable to update</param>
+    /// <param name="newVersion">The new version to set</param>
     /// <returns><see langword="true"/> when at least one file was updated; otherwise <see langword="false"/>.</returns>
-    bool UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion);
+    bool TryUpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion);
 
     /// <summary>
     /// Updates a literal <c>#:package</c> or <c>#:sdk</c> directive in a file-based app source file.
@@ -67,7 +74,10 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         _fileBasedAppScanCache.Clear();
     }
 
-    public bool UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
+    public void UpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion) =>
+        TryUpdatePackageVariable(variableInfo, newVersion);
+
+    public bool TryUpdatePackageVariable(PackageVariableInfo variableInfo, NuGetVersion newVersion)
     {
         try
         {
@@ -631,10 +641,8 @@ public sealed partial class VariableTrackingService : IVariableTrackingService
         }
 
         var propertyName = match.Groups[1].Value;
-        if (!propertyDefinitions.ContainsKey(propertyName))
-        {
-            propertyDefinitions[propertyName] = (match.Groups[2].Value, filePath);
-        }
+        // Later #:property lines in the same file override earlier ones (MSBuild-like semantics).
+        propertyDefinitions[propertyName] = (match.Groups[2].Value, filePath);
     }
 
     private static void ScanFileBasedAppPackageLine(

--- a/test-projects/file-based-app-sdk/app.cs
+++ b/test-projects/file-based-app-sdk/app.cs
@@ -1,0 +1,5 @@
+#!/usr/bin/env dotnet
+#:property TargetFramework=net10.0
+#:sdk Cake.Sdk@6.0.0
+
+Console.WriteLine("File-based app with an SDK directive");

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -329,7 +329,7 @@ Information(""Outdated Sdk"");")
                     NameExpression = "$(SdkId)",
                     VersionExpression = "6.0.0",
                     ResolvedVersion = new NuGetVersion("6.0.0"),
-                    VersionRange = new VersionRange(new NuGetVersion("6.0.0"))
+                    VersionRange = FileBasedAppReferenceHelper.CreateExactVersionRange(new NuGetVersion("6.0.0"))
                 }
             ]);
 
@@ -338,6 +338,8 @@ Information(""Outdated Sdk"");")
             var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
 
             Assert.False(result.IsSuccess);
+            Assert.Contains("literal #:sdk Cake.Sdk@<version>", result.Output);
+            Assert.Contains("#:property", result.Output);
             dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
             variableTracking.DidNotReceive().UpdateFileBasedAppDirectReference(
                 Arg.Any<string>(),

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -33,7 +33,10 @@ namespace DotNetOutdated.Tests
         private static IVariableTrackingService EmptyVariableTrackingService()
         {
             var mock = Substitute.For<IVariableTrackingService>();
-            mock.DiscoverPackageVariables(default).ReturnsForAnyArgs(new Dictionary<string, PackageVariableInfo>());
+            mock.DiscoverPackageVariables(default).ReturnsForAnyArgs([]);
+            mock.DiscoverFileBasedAppReferences(default).ReturnsForAnyArgs([]);
+            mock.UpdatePackageVariable(default, default).ReturnsForAnyArgs(true);
+            mock.UpdateFileBasedAppDirectReference(default, default, default, default).ReturnsForAnyArgs(true);
             return mock;
         }
 
@@ -279,9 +282,93 @@ Console.WriteLine();")
                     a[3] == "Humanizer" &&
                     a[4] == "-v" &&
                     a[5] == "3.0.11" &&
-                    a[6] == "-f" &&
-                    a[7] == "net10.0" &&
-                    a[8] == "--no-restore"));
+                    a[6] == "--no-restore"));
+        }
+
+        [Fact]
+        public void FileBasedAppDirectSdk_UpdatesDirectiveWithoutFrameworkFlag()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk Cake.Sdk@6.0.0
+Information(""Outdated Sdk"");")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            dotNetRunner.Run(default, default).ReturnsForAnyArgs(new RunStatus("", "", 0));
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:sdk Cake.Sdk@6.2.0", content);
+            Assert.DoesNotContain("#:sdk Cake.Sdk@6.0.0", content);
+        }
+
+        [Fact]
+        public void FileBasedAppDirectSdkWithPropertyReferences_ReturnsFailureWithoutCallingDotNet()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { appPath, new MockFileData("#:sdk $(SdkId)@6.0.0") }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            var variableTracking = Substitute.For<IVariableTrackingService>();
+            variableTracking.DiscoverPackageVariables(appPath).Returns([]);
+            variableTracking.DiscoverFileBasedAppReferences(appPath).Returns(
+            [
+                new FileBasedAppReference
+                {
+                    Name = "Cake.Sdk",
+                    Kind = FileBasedAppReferenceKind.Sdk,
+                    NameExpression = "$(SdkId)",
+                    VersionExpression = "6.0.0",
+                    ResolvedVersion = new NuGetVersion("6.0.0"),
+                    VersionRange = new VersionRange(new NuGetVersion("6.0.0"))
+                }
+            ]);
+
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, variableTracking);
+
+            var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
+
+            Assert.False(result.IsSuccess);
+            dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
+            variableTracking.DidNotReceive().UpdateFileBasedAppDirectReference(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<FileBasedAppReferenceKind>(),
+                Arg.Any<NuGetVersion>());
+        }
+
+        [Fact]
+        public void FileBasedAppVariableSdkIdAndVersion_UpdatesViaVariablePath()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property SdkId=Cake.Sdk
+#:property SdkVersion=6.0.0
+#:sdk $(SdkId)@$(SdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:property SdkVersion=6.2.0", content);
+            Assert.Contains("#:sdk $(SdkId)@$(SdkVersion)", content);
         }
     }
 }

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -329,7 +329,7 @@ Information(""Outdated Sdk"");")
                     NameExpression = "$(SdkId)",
                     VersionExpression = "6.0.0",
                     ResolvedVersion = new NuGetVersion("6.0.0"),
-                    VersionRange = FileBasedAppReferenceHelper.CreateExactVersionRange(new NuGetVersion("6.0.0"))
+                    VersionRange = FileBasedAppReferenceHelper.CreateMinimumVersionRange(new NuGetVersion("6.0.0"))
                 }
             ]);
 

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -338,8 +338,8 @@ Information(""Outdated Sdk"");")
             var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
 
             Assert.False(result.IsSuccess);
-            Assert.Contains("literal #:sdk Cake.Sdk@<version>", result.Output);
-            Assert.Contains("#:property", result.Output);
+            Assert.Contains("Direct #:sdk updates require a literal id@version", result.Errors);
+            Assert.Contains("#:property", result.Errors);
             dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
             variableTracking.DidNotReceive().UpdateFileBasedAppDirectReference(
                 Arg.Any<string>(),
@@ -371,6 +371,51 @@ Information(""Outdated Sdk"");")
             var content = mockFileSystem.File.ReadAllText(appPath);
             Assert.Contains("#:property SdkVersion=6.2.0", content);
             Assert.Contains("#:sdk $(SdkId)@$(SdkVersion)", content);
+        }
+
+        [Fact]
+        public void FileBasedAppVariableUpdate_NoOpWhenAlreadyAtVersion_ReturnsSuccess()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property SdkId=Cake.Sdk
+#:property SdkVersion=6.2.0
+#:sdk $(SdkId)@$(SdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:property SdkVersion=6.2.0", content);
+        }
+
+        [Fact]
+        public void FileBasedAppDirectSdk_NoOpWhenAlreadyAtVersion_ReturnsSuccess()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk Cake.Sdk@6.2.0
+Information(""Outdated Sdk"");")
+                }
+            });
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            var service = new DotNetPackageService(dotNetRunner, mockFileSystem, new VariableTrackingService(mockFileSystem));
+
+            var result = service.AddPackage(appPath, "Cake.Sdk", "net10.0", new NuGetVersion("6.2.0"), noRestore: true);
+
+            Assert.True(result.IsSuccess);
+            dotNetRunner.DidNotReceiveWithAnyArgs().Run(default, default);
+            Assert.Contains("#:sdk Cake.Sdk@6.2.0", mockFileSystem.File.ReadAllText(appPath));
         }
     }
 }

--- a/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DotNetPackageServiceTests.cs
@@ -35,7 +35,7 @@ namespace DotNetOutdated.Tests
             var mock = Substitute.For<IVariableTrackingService>();
             mock.DiscoverPackageVariables(default).ReturnsForAnyArgs([]);
             mock.DiscoverFileBasedAppReferences(default).ReturnsForAnyArgs([]);
-            mock.UpdatePackageVariable(default, default).ReturnsForAnyArgs(true);
+            mock.TryUpdatePackageVariable(default, default).ReturnsForAnyArgs(true);
             mock.UpdateFileBasedAppDirectReference(default, default, default, default).ReturnsForAnyArgs(true);
             return mock;
         }

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -127,6 +127,56 @@ public static class EndToEndTests
         Assert.DoesNotContain("#:package Newtonsoft.Json@11.0.1", content);
     }
 
+    [RequiresFileBasedAppSdk]
+    public static void Can_Analyze_File_Based_App_With_Sdk_Directive()
+    {
+        using var project = TestSetup("file-based-app-sdk");
+
+        var appPath = Path.Combine(project.Path, "app.cs");
+        var outputPath = Path.Combine(project.Path, "output.json");
+
+        var actual = Program.Main([appPath, "--output", outputPath, "--output-format:json"]);
+        Assert.Equal(0, actual);
+
+        using var output = JsonDocument.Parse(File.ReadAllText(outputPath));
+        var analyzedProject = Assert.Single(output.RootElement.GetProperty("Projects").EnumerateArray());
+
+        Assert.Equal("app.cs", analyzedProject.GetProperty("Name").GetString());
+        Assert.Equal(Path.GetFullPath(appPath), analyzedProject.GetProperty("FilePath").GetString());
+
+        var dependencies = analyzedProject
+            .GetProperty("TargetFrameworks")
+            .EnumerateArray()
+            .SelectMany(targetFramework => targetFramework.GetProperty("Dependencies").EnumerateArray())
+            .ToList();
+
+        Assert.Contains(dependencies, dependency => dependency.GetProperty("Name").GetString() == "Cake.Sdk");
+        Assert.DoesNotContain(dependencies, dependency => dependency.GetProperty("Name").GetString() == "Cake.Generator");
+
+        var analyzedSdk = Assert.Single(dependencies, dependency => dependency.GetProperty("Name").GetString() == "Cake.Sdk");
+
+        Assert.Equal("6.0.0", analyzedSdk.GetProperty("ResolvedVersion").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(analyzedSdk.GetProperty("LatestVersion").GetString()));
+        Assert.NotEqual("6.0.0", analyzedSdk.GetProperty("LatestVersion").GetString());
+    }
+
+    [RequiresFileBasedAppSdk]
+    public static void Can_Upgrade_File_Based_App_With_Sdk_Directive()
+    {
+        using var project = TestSetup("file-based-app-sdk");
+
+        var appPath = Path.Combine(project.Path, "app.cs");
+
+        var actual = Program.Main([appPath, "--upgrade", "--no-restore"]);
+        Assert.Equal(0, actual);
+
+        var content = File.ReadAllText(appPath);
+
+        Assert.Contains("#:sdk Cake.Sdk@", content);
+        Assert.DoesNotContain("#:sdk Cake.Sdk@6.0.0", content);
+        Assert.DoesNotContain("Cake.Generator", content);
+    }
+
     [Fact]
     public static void Can_Upgrade_Project_With_Maximum_Version()
     {

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -51,6 +51,7 @@ internal static class DotNetSdkDetector
             if (!process.WaitForExit(milliseconds: 10_000))
             {
                 process.Kill(entireProcessTree: true);
+                process.WaitForExit(milliseconds: 5_000);
                 return false;
             }
 

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -10,6 +10,69 @@ using Xunit;
 
 namespace DotNetOutdated.Tests;
 
+/// <summary>
+/// Skips the test when the installed .NET SDK is older than the minimum required for file-based apps.
+/// Inherits <see cref="FactAttribute"/> so xUnit discovers and runs the test method.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class RequiresFileBasedAppSdkAttribute : FactAttribute
+{
+    private static readonly Version MinimumSdkVersion = new(10, 0, 300);
+
+    public RequiresFileBasedAppSdkAttribute()
+    {
+        if (!DotNetSdkDetector.HasSdkVersionAtLeast(MinimumSdkVersion))
+        {
+            Skip = $"Requires .NET SDK {MinimumSdkVersion} or newer.";
+        }
+    }
+}
+
+internal static class DotNetSdkDetector
+{
+    public static bool HasSdkVersionAtLeast(Version minimumVersion)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo("dotnet", "--list-sdks")
+            {
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            });
+
+            if (process is null)
+            {
+                return false;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+
+            if (!process.WaitForExit(milliseconds: 10_000))
+            {
+                process.Kill(entireProcessTree: true);
+                return false;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                return false;
+            }
+
+            return output
+                .Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
+                .Where(sdkVersion => !string.IsNullOrWhiteSpace(sdkVersion))
+                .Select(sdkVersion => sdkVersion!.Split('-')[0])
+                .Any(sdkVersion => Version.TryParse(sdkVersion, out var version) && version.CompareTo(minimumVersion) >= 0);
+        }
+        catch (Win32Exception)
+        {
+            return false;
+        }
+    }
+}
+
 public static class EndToEndTests
 {
     [Theory]
@@ -312,64 +375,6 @@ public static class EndToEndTests
         {
             const string Prefix = "dotnet-bumper-";
             return Directory.CreateTempSubdirectory(Prefix);
-        }
-    }
-
-    public sealed class RequiresFileBasedAppSdkAttribute : FactAttribute
-    {
-        private static readonly Version MinimumSdkVersion = new(10, 0, 300);
-
-        public RequiresFileBasedAppSdkAttribute()
-        {
-            if (!DotNetSdkDetector.HasSdkVersionAtLeast(MinimumSdkVersion))
-            {
-                Skip = $"Requires .NET SDK {MinimumSdkVersion} or newer.";
-            }
-        }
-    }
-
-    internal static class DotNetSdkDetector
-    {
-        public static bool HasSdkVersionAtLeast(Version minimumVersion)
-        {
-            try
-            {
-                using var process = Process.Start(new ProcessStartInfo("dotnet", "--list-sdks")
-                {
-                    CreateNoWindow = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false
-                });
-
-                if (process is null)
-                {
-                    return false;
-                }
-
-                var output = process.StandardOutput.ReadToEnd();
-
-                if (!process.WaitForExit(milliseconds: 10_000))
-                {
-                    process.Kill(entireProcessTree: true);
-                    return false;
-                }
-
-                if (process.ExitCode != 0)
-                {
-                    return false;
-                }
-
-                return output
-                    .Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries)
-                    .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
-                    .Where(sdkVersion => !string.IsNullOrWhiteSpace(sdkVersion))
-                    .Select(sdkVersion => sdkVersion!.Split('-')[0])
-                    .Any(sdkVersion => Version.TryParse(sdkVersion, out var version) && version.CompareTo(minimumVersion) >= 0);
-            }
-            catch (Win32Exception)
-            {
-                return false;
-            }
         }
     }
 }

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -642,6 +642,36 @@ Information(""Outdated Sdk"");")
             Assert.Equal(new NuGetVersion("6.0.0"), result.ResolvedVersion);
             Assert.Equal(FileBasedAppReferenceKind.Sdk, result.Kind);
             Assert.Null(result.VariableInfo);
+            Assert.Equal(result.ResolvedVersion, result.VersionRange.MinVersion);
+            Assert.Equal(result.ResolvedVersion, result.VersionRange.MaxVersion);
+            Assert.True(result.VersionRange.IsMinInclusive);
+            Assert.True(result.VersionRange.IsMaxInclusive);
+        }
+
+        [Fact]
+        public void Discover_FileBasedApp_SdkBeforePropertyDefinitions_ResolvesForwardReferences()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk $(SdkId)@$(SdkVersion)
+#:property SdkId=Cake.Sdk
+#:property SdkVersion=6.0.0
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var variableInfo = Assert.Contains("Cake.Sdk", service.DiscoverPackageVariables(appPath));
+            Assert.Equal("SdkVersion", variableInfo.VariableName);
+            Assert.Equal("6.0.0", variableInfo.VariableValue);
+
+            var reference = Assert.Single(service.DiscoverFileBasedAppReferences(appPath), r => r.VariableInfo != null);
+            Assert.Equal("Cake.Sdk", reference.Name);
+            Assert.Equal(new NuGetVersion("6.0.0"), reference.ResolvedVersion);
+            Assert.Equal(reference.ResolvedVersion, reference.VersionRange.MinVersion);
+            Assert.Equal(reference.ResolvedVersion, reference.VersionRange.MaxVersion);
         }
 
         [Fact]

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -757,6 +757,33 @@ Information(""Outdated Sdk"");")
         }
 
         [Fact]
+        public void Discover_FileBasedAppReferences_PreservesDistinctPackageAndSdkWithSameName()
+        {
+            var appPath = XFS.Path(@"c:\repo\app.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:package SharedId@1.0.0
+#:sdk SharedId@2.0.0
+Console.WriteLine();")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var references = service.DiscoverFileBasedAppReferences(appPath);
+
+            Assert.Equal(2, references.Count);
+            Assert.Contains(references, reference =>
+                reference.Kind == FileBasedAppReferenceKind.Package &&
+                reference.Name == "SharedId" &&
+                reference.ResolvedVersion == new NuGetVersion("1.0.0"));
+            Assert.Contains(references, reference =>
+                reference.Kind == FileBasedAppReferenceKind.Sdk &&
+                reference.Name == "SharedId" &&
+                reference.ResolvedVersion == new NuGetVersion("2.0.0"));
+        }
+
+        [Fact]
         public void Update_FileBasedApp_VariableSdkIdAndVersion_PreservesExpressions()
         {
             var appPath = XFS.Path(@"c:\repo\cake.cs");

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -624,6 +624,30 @@ Information(""Outdated Sdk"");")
         }
 
         [Fact]
+        public void Discover_FileBasedApp_LaterPropertyDefinitionWinsWithinFile()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property SdkVersion=6.0.0
+#:property SdkVersion=6.2.0
+#:sdk Cake.Sdk@$(SdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var variableInfo = Assert.Contains("Cake.Sdk", service.DiscoverPackageVariables(appPath));
+
+            Assert.Equal("6.2.0", variableInfo.VariableValue);
+            Assert.Equal("SdkVersion", variableInfo.VariableName);
+
+            var reference = Assert.Single(service.DiscoverFileBasedAppReferences(appPath), r => r.VariableInfo != null);
+            Assert.Equal(new NuGetVersion("6.2.0"), reference.ResolvedVersion);
+        }
+
+        [Fact]
         public void Discover_FileBasedAppReferences_IncludesDirectSdkDirective()
         {
             var appPath = XFS.Path(@"c:\repo\cake.cs");
@@ -814,7 +838,7 @@ Information(""Outdated Sdk"");")
             var service = new VariableTrackingService(mockFileSystem);
             var variableInfo = service.DiscoverPackageVariables(appPath)["Cake.Sdk"];
 
-            Assert.True(service.UpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
+            Assert.True(service.TryUpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
 
             var content = mockFileSystem.File.ReadAllText(appPath);
             Assert.Contains("#:property SdkVersion=6.2.0", content);
@@ -838,7 +862,7 @@ Information(""Outdated Sdk"");")
             var service = new VariableTrackingService(mockFileSystem);
             var variableInfo = service.DiscoverPackageVariables(appPath)["Cake.Sdk"];
 
-            Assert.True(service.UpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
+            Assert.True(service.TryUpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
 
             var content = mockFileSystem.File.ReadAllText(appPath);
             Assert.Contains("#:sdk $(SdkId)@6.2.0", content);

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -665,6 +665,26 @@ Information(""Outdated Sdk"");")
         }
 
         [Fact]
+        public void Update_FileBasedAppDirectSdk_PreservesTrailingContentOnDirectiveLine()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk Cake.Sdk@6.0.0 // pinned for now
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+
+            Assert.True(service.UpdateFileBasedAppDirectReference(appPath, "Cake.Sdk", FileBasedAppReferenceKind.Sdk, new NuGetVersion("6.2.0")));
+
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:sdk Cake.Sdk@6.2.0 // pinned for now", content);
+        }
+
+        [Fact]
         public void Update_FileBasedAppDirectSdk_ReturnsFalseWhenDirectiveDoesNotMatch()
         {
             var appPath = XFS.Path(@"c:\repo\cake.cs");

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -784,6 +784,20 @@ Console.WriteLine();")
         }
 
         [Fact]
+        public void GetDependencyDictionaryKey_DistinguishesPackageAndSdkWithSameName()
+        {
+            Assert.Equal(
+                "SharedId#package",
+                FileBasedAppReferenceHelper.GetDependencyDictionaryKey("SharedId", FileBasedAppReferenceKind.Package));
+            Assert.Equal(
+                "SharedId#sdk",
+                FileBasedAppReferenceHelper.GetDependencyDictionaryKey("SharedId", FileBasedAppReferenceKind.Sdk));
+            Assert.NotEqual(
+                FileBasedAppReferenceHelper.GetDependencyDictionaryKey("SharedId", FileBasedAppReferenceKind.Package),
+                FileBasedAppReferenceHelper.GetDependencyDictionaryKey("SharedId", FileBasedAppReferenceKind.Sdk));
+        }
+
+        [Fact]
         public void Update_FileBasedApp_VariableSdkIdAndVersion_PreservesExpressions()
         {
             var appPath = XFS.Path(@"c:\repo\cake.cs");

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -667,9 +667,8 @@ Information(""Outdated Sdk"");")
             Assert.Equal(FileBasedAppReferenceKind.Sdk, result.Kind);
             Assert.Null(result.VariableInfo);
             Assert.Equal(result.ResolvedVersion, result.VersionRange.MinVersion);
-            Assert.Equal(result.ResolvedVersion, result.VersionRange.MaxVersion);
             Assert.True(result.VersionRange.IsMinInclusive);
-            Assert.True(result.VersionRange.IsMaxInclusive);
+            Assert.Null(result.VersionRange.MaxVersion);
         }
 
         [Fact]
@@ -695,7 +694,7 @@ Information(""Outdated Sdk"");")
             Assert.Equal("Cake.Sdk", reference.Name);
             Assert.Equal(new NuGetVersion("6.0.0"), reference.ResolvedVersion);
             Assert.Equal(reference.ResolvedVersion, reference.VersionRange.MinVersion);
-            Assert.Equal(reference.ResolvedVersion, reference.VersionRange.MaxVersion);
+            Assert.Null(reference.VersionRange.MaxVersion);
         }
 
         [Fact]

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -738,6 +738,50 @@ Information(""Outdated Sdk"");")
         }
 
         [Fact]
+        public void Discover_FileBasedAppReferences_DiscoversDirectSdkWithTrailingComment()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk Cake.Sdk@6.0.0 // pinned for now
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var reference = service.DiscoverFileBasedAppReferences(appPath).Single();
+
+            Assert.Equal("Cake.Sdk", reference.Name);
+            Assert.Equal(new NuGetVersion("6.0.0"), reference.ResolvedVersion);
+            Assert.Equal(FileBasedAppReferenceKind.Sdk, reference.Kind);
+        }
+
+        [Fact]
+        public void Update_FileBasedApp_VariableSdkVersion_PropertyNameCasingDiffersFromReference()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    // The #:property name (sdkversion) differs in case from the $(SdkVersion) reference.
+                    appPath, new MockFileData(@"#:property sdkversion=6.0.0
+#:sdk Cake.Sdk@$(SdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var variableInfo = service.DiscoverPackageVariables(appPath)["Cake.Sdk"];
+
+            Assert.True(service.TryUpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
+
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:property sdkversion=6.2.0", content);
+            Assert.DoesNotContain("6.0.0", content);
+        }
+
+        [Fact]
         public void Update_FileBasedAppDirectSdk_ReturnsFalseWhenDirectiveDoesNotMatch()
         {
             var appPath = XFS.Path(@"c:\repo\cake.cs");

--- a/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
+++ b/test/DotNetOutdated.Tests/VariableTrackingServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.IO.Abstractions.TestingHelpers;
 using DotNetOutdated.Core.Services;
 using NuGet.Versioning;
@@ -597,6 +598,160 @@ Console.WriteLine();")
             var info = Assert.Contains("Humanizer", result);
             Assert.Equal(propsPath, info.FilePath);
             Assert.Equal("3.0.10", info.VariableValue);
+        }
+
+        [Fact]
+        public void Discover_FileBasedApp_VariableSdkDirective()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property CakeSdkVersion=6.0.0
+#:sdk Cake.Sdk@$(CakeSdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var result = service.DiscoverPackageVariables(appPath);
+
+            var info = Assert.Contains("Cake.Sdk", result);
+            Assert.Equal("CakeSdkVersion", info.VariableName);
+            Assert.Equal("6.0.0", info.VariableValue);
+            Assert.Equal(PackageVariableInfo.FileBasedSdkDirectiveElementType, info.ElementType);
+            Assert.Equal("$(CakeSdkVersion)", info.PackageReferenceVersion);
+        }
+
+        [Fact]
+        public void Discover_FileBasedAppReferences_IncludesDirectSdkDirective()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk Cake.Sdk@6.0.0
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var result = service.DiscoverFileBasedAppReferences(appPath).Single();
+
+            Assert.Equal("Cake.Sdk", result.Name);
+            Assert.Equal(new NuGetVersion("6.0.0"), result.ResolvedVersion);
+            Assert.Equal(FileBasedAppReferenceKind.Sdk, result.Kind);
+            Assert.Null(result.VariableInfo);
+        }
+
+        [Fact]
+        public void Update_FileBasedAppDirectSdk_UpdatesDirectiveLine()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk Cake.Sdk@6.0.0
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+
+            Assert.True(service.UpdateFileBasedAppDirectReference(appPath, "Cake.Sdk", FileBasedAppReferenceKind.Sdk, new NuGetVersion("6.2.0")));
+
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:sdk Cake.Sdk@6.2.0", content);
+        }
+
+        [Fact]
+        public void Update_FileBasedAppDirectSdk_ReturnsFalseWhenDirectiveDoesNotMatch()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:sdk $(SdkId)@6.0.0
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+
+            Assert.False(service.UpdateFileBasedAppDirectReference(appPath, "Cake.Sdk", FileBasedAppReferenceKind.Sdk, new NuGetVersion("6.2.0")));
+            Assert.Contains("#:sdk $(SdkId)@6.0.0", mockFileSystem.File.ReadAllText(appPath));
+        }
+
+        [Fact]
+        public void Discover_FileBasedAppReferences_PrefersVariableBackedSdkEntry()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property SdkId=Cake.Sdk
+#:property SdkVersion=6.0.0
+#:sdk $(SdkId)@$(SdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var reference = service.DiscoverFileBasedAppReferences(appPath).Single();
+
+            Assert.Equal("Cake.Sdk", reference.Name);
+            Assert.NotNull(reference.VariableInfo);
+            Assert.Equal("$(SdkId)", reference.NameExpression);
+            Assert.Equal("$(SdkVersion)", reference.VersionExpression);
+            Assert.True(reference.UsesPropertyReferences);
+        }
+
+        [Fact]
+        public void Update_FileBasedApp_VariableSdkIdAndVersion_PreservesExpressions()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property SdkId=Cake.Sdk
+#:property SdkVersion=6.0.0
+#:sdk $(SdkId)@$(SdkVersion)
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var variableInfo = service.DiscoverPackageVariables(appPath)["Cake.Sdk"];
+
+            Assert.True(service.UpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
+
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:property SdkVersion=6.2.0", content);
+            Assert.Contains("#:sdk $(SdkId)@$(SdkVersion)", content);
+            Assert.DoesNotContain("#:property SdkVersion=6.0.0", content);
+        }
+
+        [Fact]
+        public void Update_FileBasedApp_VariableSdkIdLiteralVersion_UpdatesDirectiveLine()
+        {
+            var appPath = XFS.Path(@"c:\repo\cake.cs");
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    appPath, new MockFileData(@"#:property SdkId=Cake.Sdk
+#:sdk $(SdkId)@6.0.0
+Information(""Outdated Sdk"");")
+                }
+            });
+
+            var service = new VariableTrackingService(mockFileSystem);
+            var variableInfo = service.DiscoverPackageVariables(appPath)["Cake.Sdk"];
+
+            Assert.True(service.UpdatePackageVariable(variableInfo, new NuGetVersion("6.2.0")));
+
+            var content = mockFileSystem.File.ReadAllText(appPath);
+            Assert.Contains("#:sdk $(SdkId)@6.2.0", content);
+            Assert.DoesNotContain("#:sdk $(SdkId)@6.0.0", content);
         }
     }
 }


### PR DESCRIPTION
### Summary

* Add support for MSBuild SDK packages declared with `#:sdk` in file-based apps (for example `#:sdk Cake.Sdk@6.0.0`)
* Report SDK directives from the `.cs` source instead of transient SDK-expanded dependencies from the restore graph
* Update `#:sdk` directives, including variable-backed ids and versions through `#:property` (for example `#:sdk $(SdkId)@$(SdkVersion)`)
* Rewrite literal `#:sdk` lines in-place; fail upgrades when no matching directive was changed
* Omit `-f` / `--framework` when running `dotnet add package` on `.cs` paths (newer SDKs i.e. .NET 11 will fail and reject it)
* Add `test-projects/file-based-app-sdk` fixture, unit/integration/e2e tests, and a CI smoke test on the existing file-based-app job (SDK 10.0.300)

Builds on file-based app support from [#752](https://github.com/dotnet-outdated/dotnet-outdated/pull/752) (`#:package` and `#:property`).

### Changes

* New `FileBasedAppReference` model with directive expressions and `UsesPropertyReferences` guard
* `VariableTrackingService`: parse/upgrade `#:sdk`, compile-time regex sources, prefer variable-backed entries when deduplicating discoveries
* `ProjectAnalysisService`: merge `#:package` / `#:sdk` directives into authoritative dependencies for file-based apps
* `DotNetPackageService`: route SDK upgrades through variable or direct file rewrite paths; return failure when nothing changes
* README: document `#:sdk`; FAQ points to [dotnet/sdk](https://github.com/dotnet/sdk) ([dotnet/cli](https://github.com/dotnet/cli) is archived)

### Validation

* `dotnet build --configuration Release`
* `dotnet test --configuration Release --framework net9.0`
* `dotnet test --configuration Release --framework net9.0 --filter "FullyQualifiedName~FileBasedApp|FullyQualifiedName~File_Based_App"`
* `dotnet run --configuration Release --framework net9.0 --project src/DotNetOutdated -- test-projects/file-based-app-sdk/app.cs --fail-on-updates` (expects exit code 2)
* Manual: `dotnet outdated <path-to-cake.cs> -u` updates `#:sdk Cake.Sdk@…` in place