### PR TITLE
Show a friendly message instead of crashing when a solution has no projects

### DIFF
--- a/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.Designer.cs
+++ b/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.Designer.cs
@@ -103,5 +103,14 @@ namespace DotNetOutdated.Core.Resources {
                 return ResourceManager.GetString("FileNotAValidSolutionOrProject", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No projects were found to analyze in &apos;{0}&apos;. Make sure the solution references at least one project..
+        /// </summary>
+        internal static string NoRestorableProjectsFound {
+            get {
+                return ResourceManager.GetString("NoRestorableProjectsFound", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.resx
+++ b/src/DotNetOutdated.Core/Resources/ValidationErrorMessages.resx
@@ -132,4 +132,7 @@
   <data name="FileNotAValidSolutionOrProject" xml:space="preserve">
     <value>The file '{0}' is not a valid solution, project, or file-based app.</value>
   </data>
+  <data name="NoRestorableProjectsFound" xml:space="preserve">
+    <value>No projects were found to analyze in '{0}'. Make sure the solution references at least one project.</value>
+  </data>
 </root>

--- a/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
+++ b/src/DotNetOutdated.Core/Services/DependencyGraphService.cs
@@ -3,6 +3,7 @@ using DotNetOutdated.Core.Exceptions;
 using NuGet.ProjectModel;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 
@@ -29,6 +30,11 @@ namespace DotNetOutdated.Core.Services
 
             if (runStatus.IsSuccess)
             {
+                // A solution or project with no restorable projects (e.g. an empty solution) makes
+                // MSBuild report success without ever writing the restore graph file.
+                if (!_fileSystem.File.Exists(dgOutput))
+                    throw new CommandValidationException(string.Format(CultureInfo.InvariantCulture, Resources.ValidationErrorMessages.NoRestorableProjectsFound, projectPath));
+
                 var dependencyGraphText = await _fileSystem.File.ReadAllTextAsync(dgOutput).ConfigureAwait(false);
                 return new ExtendedDependencyGraphSpec(dependencyGraphText);
             }

--- a/test-projects/empty-solution/Empty.sln
+++ b/test-projects/empty-solution/Empty.sln
@@ -1,0 +1,11 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
+++ b/test/DotNetOutdated.Tests/DependencyGraphServiceTests.cs
@@ -103,6 +103,24 @@ namespace DotNetOutdated.Tests
         }
 
         [Fact]
+        public async Task SuccessfulRunWithoutGraphFileThrowsFriendlyValidationException()
+        {
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            // Arrange: MSBuild reports success but never writes the restore graph
+            // file, as happens when the solution references no projects (issue #747).
+            var dotNetRunner = Substitute.For<IDotNetRunner>();
+            dotNetRunner.Run(Arg.Any<string>(), Arg.Any<string[]>())
+                .Returns(new RunStatus(string.Empty, string.Empty, exitCode: 0));
+
+            var graphService = new DependencyGraphService(dotNetRunner, mockFileSystem);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<CommandValidationException>(() => graphService.GenerateDependencyGraphAsync(_solutionPath, string.Empty));
+            Assert.Contains(_solutionPath, exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public async Task FileBasedAppGeneratesDependencyGraphWithRestoreThenBuild()
         {
             var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());

--- a/test/DotNetOutdated.Tests/EndToEndTests.cs
+++ b/test/DotNetOutdated.Tests/EndToEndTests.cs
@@ -242,6 +242,15 @@ public static class EndToEndTests
     }
 
     [Fact]
+    public static void Reports_Friendly_Message_For_Solution_With_No_Projects()
+    {
+        using var project = TestSetup("empty-solution");
+
+        var actual = Program.Main([project.Path]);
+        Assert.Equal(1, actual);
+    }
+
+    [Fact]
     public static void Can_Upgrade_Project_With_Maximum_Version()
     {
         using var directory = TestSetup("max-version");


### PR DESCRIPTION
Closes #747.

## What's wrong

Running `dotnet outdated` against a solution that references no projects (e.g. one an AI agent scaffolded but hasn't populated yet) crashes with an unhandled `System.IO.FileNotFoundException` instead of a clean message. Per the reporter:

```
Unhandled exception. System.IO.FileNotFoundException: Could not find file 'C:\Users\...\AppData\Local\Temp\2zbjhlwk.elv'.
...
   at DotNetOutdated.Core.Services.DependencyGraphService.GenerateDependencyGraphAsync(...)
   at DotNetOutdated.Core.Services.ProjectAnalysisService.AnalyzeProjectAsync(...)
```

## Root cause

When the target solution/project has zero restorable projects, `dotnet msbuild ... /t:Restore,GenerateRestoreGraphFile` exits successfully but never writes the `RestoreGraphOutputPath` file (nothing to restore). `DependencyGraphService` unconditionally read that file on success, so the missing-file read escaped as a raw, unhandled I/O exception.

## What changed

`DependencyGraphService.GenerateDependencyGraphAsync` now checks whether the restore graph file actually exists before reading it, and throws the same `CommandValidationException` the method already uses for the restore-failure branch — which the CLI already catches and reports cleanly — with a new friendly message ("No projects were found to analyze in '{path}'. Make sure the solution references at least one project.").

## Testing

- Added `test-projects/empty-solution/` (a real `.sln` with zero project references) + an end-to-end test that runs the CLI against it and asserts a clean exit instead of a crash.
- Added a unit test in `DependencyGraphServiceTests` that mocks the MSBuild-succeeds-but-no-output-file case directly.
- Full suite: 209 tests, 208 passed, 1 pre-existing unrelated skip, 0 failed.
- Manually reproduced the exact crash from the issue on the pre-fix build, and confirmed the fix replaces it with a friendly message (exit code 1, no stack trace).
