### PR TITLE
Report packages whose source repo is archived or deleted (GitHub only)

### DIFF
--- a/src/DotNetOutdated.Core/Models/RepositoryStatus.cs
+++ b/src/DotNetOutdated.Core/Models/RepositoryStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace DotNetOutdated.Core.Models
+{
+    public enum RepositoryStatus
+    {
+        Unknown,
+        Active,
+        Archived,
+        NotFound
+    }
+}

--- a/src/DotNetOutdated.Core/Services/GitHubRepositoryStatusService.cs
+++ b/src/DotNetOutdated.Core/Services/GitHubRepositoryStatusService.cs
@@ -1,0 +1,134 @@
+﻿using DotNetOutdated.Core.Models;
+using NuGet.Versioning;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNetOutdated.Core.Services
+{
+    public sealed class GitHubRepositoryStatusService(
+        INuGetPackageInfoService packageInfoService,
+        HttpClient httpClient) : IRepositoryStatusService
+    {
+        private readonly INuGetPackageInfoService _packageInfoService = packageInfoService;
+        private readonly HttpClient _httpClient = httpClient;
+        private readonly ConcurrentDictionary<string, Lazy<Task<RepositoryStatus>>> _statusRequests = new(StringComparer.OrdinalIgnoreCase);
+
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Repository checks must never fail package analysis")]
+        public async Task<RepositoryStatus> GetRepositoryStatus(
+            string packageName,
+            NuGetVersion packageVersion,
+            IEnumerable<Uri> sources,
+            string projectFilePath)
+        {
+            if (packageVersion == null)
+                return RepositoryStatus.Unknown;
+
+            try
+            {
+                string repositoryUrl = await _packageInfoService.GetRepositoryUrl(
+                    packageName,
+                    packageVersion,
+                    sources,
+                    projectFilePath).ConfigureAwait(false);
+
+                return await GetRepositoryStatus(repositoryUrl).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return RepositoryStatus.Unknown;
+            }
+        }
+
+        internal Task<RepositoryStatus> GetRepositoryStatus(string repositoryUrl)
+        {
+            // Issue #200 intentionally supports GitHub only; other hosts need provider-specific status semantics and APIs.
+            if (!TryGetGitHubRepository(repositoryUrl, out string owner, out string repository))
+                return Task.FromResult(RepositoryStatus.Unknown);
+
+            string cacheKey = $"{owner}/{repository}";
+            var request = new Lazy<Task<RepositoryStatus>>(() => GetGitHubRepositoryStatus(owner, repository));
+            return _statusRequests.GetOrAdd(cacheKey, request).Value;
+        }
+
+        internal static bool TryGetGitHubRepository(string repositoryUrl, out string owner, out string repository)
+        {
+            owner = null;
+            repository = null;
+
+            if (string.IsNullOrWhiteSpace(repositoryUrl))
+                return false;
+
+            string scpPrefix = "git@github.com:";
+            if (repositoryUrl.StartsWith(scpPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return TryGetOwnerAndRepository(repositoryUrl[scpPrefix.Length..], out owner, out repository);
+            }
+
+            if (!Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var uri) ||
+                !(uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase) ||
+                  uri.Host.Equals("www.github.com", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            return TryGetOwnerAndRepository(uri.AbsolutePath, out owner, out repository);
+        }
+
+        private static bool TryGetOwnerAndRepository(string path, out string owner, out string repository)
+        {
+            owner = null;
+            repository = null;
+
+            string[] segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 2)
+                return false;
+
+            owner = segments[0];
+            repository = segments[1];
+            if (repository.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                repository = repository[..^4];
+
+            return owner.Length > 0 && repository.Length > 0;
+        }
+
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Repository checks must never fail package analysis")]
+        private async Task<RepositoryStatus> GetGitHubRepositoryStatus(string owner, string repository)
+        {
+            try
+            {
+                var apiUrl = new Uri($"https://api.github.com/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repository)}");
+                using var request = new HttpRequestMessage(HttpMethod.Get, apiUrl);
+                request.Headers.UserAgent.ParseAdd("dotnet-outdated");
+                request.Headers.Accept.ParseAdd("application/vnd.github+json");
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+                using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                    return RepositoryStatus.NotFound;
+                if (response.StatusCode != HttpStatusCode.OK)
+                    return RepositoryStatus.Unknown;
+
+                await using var content = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                using var document = await JsonDocument.ParseAsync(content).ConfigureAwait(false);
+                if (!document.RootElement.TryGetProperty("archived", out var archived) ||
+                    (archived.ValueKind != JsonValueKind.True && archived.ValueKind != JsonValueKind.False))
+                {
+                    return RepositoryStatus.Unknown;
+                }
+
+                return archived.GetBoolean() ? RepositoryStatus.Archived : RepositoryStatus.Active;
+            }
+            catch (Exception)
+            {
+                return RepositoryStatus.Unknown;
+            }
+        }
+    }
+}

--- a/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/INuGetPackageInfoService.cs
@@ -13,5 +13,7 @@ namespace DotNetOutdated.Core.Services
 
         Task<IReadOnlyList<NuGetVersion>> GetAllVersions(string package, IEnumerable<Uri> sources, bool includePrerelease, NuGetFramework targetFramework, string projectFilePath,
             bool isDevelopmentDependency, int olderThanDays, bool ignoreFailedSources);
+
+        Task<string> GetRepositoryUrl(string package, NuGetVersion version, IEnumerable<Uri> sources, string projectFilePath);
     }
 }

--- a/src/DotNetOutdated.Core/Services/IRepositoryStatusService.cs
+++ b/src/DotNetOutdated.Core/Services/IRepositoryStatusService.cs
@@ -1,0 +1,17 @@
+﻿using DotNetOutdated.Core.Models;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DotNetOutdated.Core.Services
+{
+    public interface IRepositoryStatusService
+    {
+        Task<RepositoryStatus> GetRepositoryStatus(
+            string packageName,
+            NuGetVersion packageVersion,
+            IEnumerable<Uri> sources,
+            string projectFilePath);
+    }
+}

--- a/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
+++ b/src/DotNetOutdated.Core/Services/NuGetPackageInfoService.cs
@@ -1,11 +1,14 @@
 ﻿using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -19,11 +22,15 @@ namespace DotNetOutdated.Core.Services
     {
         private IEnumerable<PackageSource> _enabledSources;
 
+        private ISettings _settings;
+
         private PackageSourceMapping _packageSourceMapping;
 
         private readonly SourceCacheContext _context;
 
         private readonly ConcurrentDictionary<string, Task<PackageMetadataResource>> _metadataResourceRequests = [];
+
+        private readonly ConcurrentDictionary<string, Lazy<Task<string>>> _repositoryUrlRequests = [];
 
         public NuGetPackageInfoService()
         {
@@ -37,16 +44,16 @@ namespace DotNetOutdated.Core.Services
         {
             if (_enabledSources == null)
             {
-                var settings = Settings.LoadDefaultSettings(root);
-                _enabledSources = SettingsUtility.GetEnabledSources(settings);
-                _packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+                _settings = Settings.LoadDefaultSettings(root);
+                _enabledSources = SettingsUtility.GetEnabledSources(_settings);
+                _packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(_settings);
             }
 
             return _enabledSources;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This method is supposed to fail silently")]
-        private async Task<PackageMetadataResource> FindMetadataResourceForSource(Uri source, string projectFilePath, string packageId)
+        private SourceRepository FindSourceRepositoryForSource(Uri source, string projectFilePath, string packageId)
         {
             try
             {
@@ -69,10 +76,26 @@ namespace DotNetOutdated.Core.Services
                     }
                 }
 
-                var sourceRepository = enabledSource != null
+                return enabledSource != null
                                            ? new SourceRepository(enabledSource, Repository.Provider.GetCoreV3())
                                            : Repository.Factory.GetCoreV3(resourceUrl);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This method is supposed to fail silently")]
+        private async Task<PackageMetadataResource> FindMetadataResourceForSource(Uri source, string projectFilePath, string packageId)
+        {
+            try
+            {
+                var sourceRepository = FindSourceRepositoryForSource(source, projectFilePath, packageId);
+                if (sourceRepository == null)
+                    return null;
+
+                string resourceUrl = source.AbsoluteUri;
                 var metadataResourceRequest = _metadataResourceRequests.GetOrAdd(resourceUrl, _ => sourceRepository.GetResourceAsync<PackageMetadataResource>());
 
                 return await metadataResourceRequest.ConfigureAwait(false);
@@ -158,6 +181,71 @@ namespace DotNetOutdated.Core.Services
             }
 
             return allVersions;
+        }
+
+        public async Task<string> GetRepositoryUrl(string package, NuGetVersion version, IEnumerable<Uri> sources, string projectFilePath)
+        {
+            ArgumentNullException.ThrowIfNull(sources);
+
+            var sourceList = sources.ToList();
+            string cacheKey = string.Join("|", package, version, projectFilePath, string.Join(";", sourceList.Select(s => s.AbsoluteUri)));
+            var request = new Lazy<Task<string>>(() => GetRepositoryUrlCore(package, version, sourceList, projectFilePath));
+            return await _repositoryUrlRequests.GetOrAdd(cacheKey, request).Value.ConfigureAwait(false);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Repository metadata must not fail package analysis")]
+        private async Task<string> GetRepositoryUrlCore(string package, NuGetVersion version, IReadOnlyList<Uri> sources, string projectFilePath)
+        {
+            try
+            {
+                GetEnabledSources(projectFilePath);
+                string globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(_settings);
+                var pathResolver = new VersionFolderPathResolver(globalPackagesFolder);
+                string installPath = pathResolver.GetInstallPath(package, version);
+
+                if (!string.IsNullOrEmpty(installPath) && Directory.Exists(installPath))
+                {
+                    using var packageReader = new PackageFolderReader(installPath);
+                    return await GetRepositoryUrl(packageReader).ConfigureAwait(false);
+                }
+
+                foreach (var source in sources)
+                {
+                    try
+                    {
+                        var sourceRepository = FindSourceRepositoryForSource(source, projectFilePath, package);
+                        if (sourceRepository == null)
+                            continue;
+
+                        var downloadResource = await sourceRepository.GetResourceAsync<DownloadResource>().ConfigureAwait(false);
+                        var downloadContext = new PackageDownloadContext(_context);
+                        using var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                            new PackageIdentity(package, version),
+                            downloadContext,
+                            globalPackagesFolder,
+                            NullLogger.Instance,
+                            CancellationToken.None).ConfigureAwait(false);
+
+                        if (downloadResult.PackageReader != null)
+                            return await GetRepositoryUrl(downloadResult.PackageReader).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            return null;
+        }
+
+        private static async Task<string> GetRepositoryUrl(PackageReaderBase packageReader)
+        {
+            var nuspecReader = await packageReader.GetNuspecReaderAsync(CancellationToken.None).ConfigureAwait(false);
+            string repositoryUrl = nuspecReader.GetRepositoryMetadata()?.Url;
+            return string.IsNullOrWhiteSpace(repositoryUrl) ? nuspecReader.GetProjectUrl() : repositoryUrl;
         }
 
         public void Dispose()

--- a/src/DotNetOutdated/Formatters/CsvFormatter.cs
+++ b/src/DotNetOutdated/Formatters/CsvFormatter.cs
@@ -32,7 +32,8 @@ internal class CsvFormatter : IOutputFormatter
                             DependencyName = dependency.Name,
                             ResolvedVersion = dependency.ResolvedVersion?.ToString(),
                             LatestVersion = dependency.LatestVersion?.ToString(),
-                            UpgradeSeverity = upgradeSeverity
+                            UpgradeSeverity = upgradeSeverity,
+                            RepositoryStatus = Enum.GetName(dependency.RepositoryStatus)
                         });
                     }
                 }

--- a/src/DotNetOutdated/Formatters/MarkdownFormatter.cs
+++ b/src/DotNetOutdated/Formatters/MarkdownFormatter.cs
@@ -34,8 +34,8 @@ internal class MarkdownFormatter : IOutputFormatter
             {
                 sb.AppendLine($"### Target:{targetFramework.Name}");
                 sb.AppendLine();
-                sb.AppendLine("|Package|Transitive|Current|Last|Severity|");
-                sb.AppendLine("|-|-|-:|-:|-:|");
+                sb.AppendLine("|Package|Transitive|Current|Last|Severity|Repository Status|");
+                sb.AppendLine("|-|-|-:|-:|-:|-|");
                 foreach (var dependency in targetFramework.Dependencies)
                 {
                     sb.Append('|');
@@ -71,7 +71,10 @@ internal class MarkdownFormatter : IOutputFormatter
                         sb.Append('$');
                     }
                     sb.Append('|');
-                    sb.AppendLine(dependency.UpgradeSeverity.ToString());
+                    sb.Append(dependency.UpgradeSeverity.ToString());
+                    sb.Append('|');
+                    sb.Append(dependency.RepositoryStatus.ToString());
+                    sb.AppendLine("|");
                 }
                 sb.AppendLine();
             }

--- a/src/DotNetOutdated/Models/AnalyzedProject.cs
+++ b/src/DotNetOutdated/Models/AnalyzedProject.cs
@@ -100,6 +100,18 @@ namespace DotNetOutdated.Models
             }
         }
 
+        [JsonPropertyOrder(4)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public RepositoryStatus RepositoryStatus { get; }
+
+        [JsonIgnore]
+        public string RepositoryStatusDescription => RepositoryStatus switch
+        {
+            DotNetOutdated.Core.Models.RepositoryStatus.Archived => "Archived",
+            DotNetOutdated.Core.Models.RepositoryStatus.NotFound => "Not Found",
+            _ => string.Empty
+        };
+
         public AnalyzedDependency(Dependency dependency)
         {
             _dependency = dependency;
@@ -108,6 +120,11 @@ namespace DotNetOutdated.Models
         public AnalyzedDependency(Dependency dependency, NuGetVersion latestVersion) : this(dependency)
         {
             LatestVersion = latestVersion;
+        }
+
+        public AnalyzedDependency(Dependency dependency, NuGetVersion latestVersion, RepositoryStatus repositoryStatus) : this(dependency, latestVersion)
+        {
+            RepositoryStatus = repositoryStatus;
         }
     }
 
@@ -119,5 +136,6 @@ namespace DotNetOutdated.Models
         public string ResolvedVersion { get; set; }
         public string LatestVersion { get; set; }
         public string UpgradeSeverity { get; set; }
+        public string RepositoryStatus { get; set; }
     }
 }

--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -1,4 +1,4 @@
-using DotNetOutdated.Core;
+﻿using DotNetOutdated.Core;
 using DotNetOutdated.Core.Exceptions;
 using DotNetOutdated.Core.Models;
 using DotNetOutdated.Core.Services;
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -36,6 +37,7 @@ namespace DotNetOutdated
         IProjectAnalysisService projectAnalysisService,
         IProjectDiscoveryService projectDiscoveryService,
         IDotNetPackageService dotNetPackageService,
+        IRepositoryStatusService repositoryStatusService,
         DotNetRunnerOptions dotNetRunnerOptions) : CommandBase
    {
       private readonly IFileSystem _fileSystem = fileSystem;
@@ -44,6 +46,7 @@ namespace DotNetOutdated
       private readonly IProjectAnalysisService _projectAnalysisService = projectAnalysisService;
       private readonly IProjectDiscoveryService _projectDiscoveryService = projectDiscoveryService;
       private readonly IDotNetPackageService _dotNetPackageService = dotNetPackageService;
+      private readonly IRepositoryStatusService _repositoryStatusService = repositoryStatusService;
       private readonly DotNetRunnerOptions _dotNetRunnerOptions = dotNetRunnerOptions;
 
       [Option(CommandOptionType.NoValue, Description = "Specifies whether to include auto-referenced packages.",
@@ -166,8 +169,10 @@ namespace DotNetOutdated
                          provider.GetService<IFileSystem>(),
                          msg => provider.GetService<IReporter>().Warn(msg)))
                  .AddSingleton<IDotNetPackageService, DotNetPackageService>()
+                 .AddSingleton(_ => new HttpClient { Timeout = TimeSpan.FromSeconds(5) })
                  .AddSingleton<INuGetPackageInfoService, NuGetPackageInfoService>()
                  .AddSingleton<INuGetPackageResolutionService, NuGetPackageResolutionService>()
+                 .AddSingleton<IRepositoryStatusService, GitHubRepositoryStatusService>()
                  .BuildServiceProvider();
 
          using var app = new CommandLineApplication<Program>();
@@ -395,6 +400,8 @@ namespace DotNetOutdated
                var dependencies = targetFramework.Dependencies;
 
                int[] columnWidths = dependencies.DetermineColumnWidths();
+               bool showRepositoryStatus = dependencies.Any(d =>
+                   d.RepositoryStatus is RepositoryStatus.Archived or RepositoryStatus.NotFound);
 
                foreach (var dependency in dependencies)
                {
@@ -402,6 +409,12 @@ namespace DotNetOutdated
                   console.Write(dependency.Description?.PadRight(columnWidths[0] + 2));
 
                   WriteColoredUpgrade(dependency.UpgradeSeverity, dependency.ResolvedVersion, dependency.LatestVersion, columnWidths[1], columnWidths[2], console);
+
+                  if (showRepositoryStatus)
+                  {
+                     console.Write("  ");
+                     console.Write(dependency.RepositoryStatusDescription.PadRight(columnWidths[3]));
+                  }
 
                   console.WriteLine();
                }
@@ -587,14 +600,29 @@ namespace DotNetOutdated
 
                if (absoluteLatestVersion == null || referencedVersion > absoluteLatestVersion)
                {
-                  outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion));
+                  await AddAnalyzedDependency(project, dependency, latestVersion, outdatedDependencies).ConfigureAwait(false);
                }
             }
             else
             {
-               outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion));
+               await AddAnalyzedDependency(project, dependency, latestVersion, outdatedDependencies).ConfigureAwait(false);
             }
          }
+      }
+
+      private async Task AddAnalyzedDependency(
+          Project project,
+          Dependency dependency,
+          NuGetVersion latestVersion,
+          ConcurrentBag<AnalyzedDependency> outdatedDependencies)
+      {
+         RepositoryStatus repositoryStatus = await _repositoryStatusService.GetRepositoryStatus(
+             dependency.Name,
+             dependency.ResolvedVersion,
+             project.Sources,
+             project.FilePath).ConfigureAwait(false);
+
+         outdatedDependencies.Add(new AnalyzedDependency(dependency, latestVersion, repositoryStatus));
       }
 
       private static ConsoleColor GetUpgradeSeverityColor(DependencyUpgradeSeverity? upgradeSeverity)

--- a/src/DotNetOutdated/ReportingExtensions.cs
+++ b/src/DotNetOutdated/ReportingExtensions.cs
@@ -15,7 +15,8 @@ namespace DotNetOutdated
             [
                 packages.Max(p => p.Description.Length),
                 packages.Max(p => p.ResolvedVersion?.ToString().Length ?? 0),
-                packages.Max(p => p.LatestVersion?.ToString().Length ?? 0)
+                packages.Max(p => p.LatestVersion?.ToString().Length ?? 0),
+                packages.Max(p => p.RepositoryStatusDescription.Length)
             ];
         }
     }

--- a/test/DotNetOutdated.Tests/GitHubRepositoryStatusServiceTests.cs
+++ b/test/DotNetOutdated.Tests/GitHubRepositoryStatusServiceTests.cs
@@ -1,0 +1,140 @@
+﻿using DotNetOutdated.Core.Models;
+using DotNetOutdated.Core.Services;
+using NSubstitute;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DotNetOutdated.Tests;
+
+public class GitHubRepositoryStatusServiceTests
+{
+    [Theory]
+    [InlineData("https://github.com/dotnet-outdated/dotnet-outdated", "dotnet-outdated", "dotnet-outdated")]
+    [InlineData("https://www.github.com/dotnet-outdated/dotnet-outdated.git", "dotnet-outdated", "dotnet-outdated")]
+    [InlineData("git@github.com:dotnet-outdated/dotnet-outdated.git", "dotnet-outdated", "dotnet-outdated")]
+    public void TryGetGitHubRepositoryParsesOwnerAndRepository(string url, string expectedOwner, string expectedRepository)
+    {
+        bool parsed = GitHubRepositoryStatusService.TryGetGitHubRepository(url, out string owner, out string repository);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedOwner, owner);
+        Assert.Equal(expectedRepository, repository);
+    }
+
+    [Theory]
+    [InlineData("https://gitlab.com/dotnet-outdated/dotnet-outdated")]
+    [InlineData("https://github.com/dotnet-outdated")]
+    [InlineData("")]
+    public void TryGetGitHubRepositoryRejectsUnsupportedUrl(string url)
+    {
+        Assert.False(GitHubRepositoryStatusService.TryGetGitHubRepository(url, out _, out _));
+    }
+
+    [Theory]
+    [InlineData(false, RepositoryStatus.Active)]
+    [InlineData(true, RepositoryStatus.Archived)]
+    public async Task GetRepositoryStatusHandlesSuccessfulResponse(bool archived, RepositoryStatus expectedStatus)
+    {
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            Assert.Equal("https://api.github.com/repos/owner/repository", request.RequestUri.AbsoluteUri);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"archived\":{archived.ToString().ToLowerInvariant()}}}")
+            });
+        });
+        var service = CreateService("https://github.com/owner/repository", handler);
+
+        RepositoryStatus status = await GetRepositoryStatus(service);
+
+        Assert.Equal(expectedStatus, status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusHandlesNotFoundResponse()
+    {
+        var handler = new StubHttpMessageHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
+        var service = CreateService("https://github.com/owner/repository", handler);
+
+        RepositoryStatus status = await GetRepositoryStatus(service);
+
+        Assert.Equal(RepositoryStatus.NotFound, status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusHandlesNetworkFailure()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => throw new HttpRequestException());
+        var service = CreateService("https://github.com/owner/repository", handler);
+
+        RepositoryStatus status = await GetRepositoryStatus(service);
+
+        Assert.Equal(RepositoryStatus.Unknown, status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusHandlesTimeout()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => throw new TaskCanceledException());
+        var service = CreateService("https://github.com/owner/repository", handler);
+
+        RepositoryStatus status = await GetRepositoryStatus(service);
+
+        Assert.Equal(RepositoryStatus.Unknown, status);
+    }
+
+    [Fact]
+    public async Task GetRepositoryStatusSkipsNonGitHubRepository()
+    {
+        int requestCount = 0;
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        var service = CreateService("https://gitlab.com/owner/repository", handler);
+
+        RepositoryStatus status = await GetRepositoryStatus(service);
+
+        Assert.Equal(RepositoryStatus.Unknown, status);
+        Assert.Equal(0, requestCount);
+    }
+
+    private static GitHubRepositoryStatusService CreateService(string repositoryUrl, HttpMessageHandler handler)
+    {
+        var packageInfoService = Substitute.For<INuGetPackageInfoService>();
+        packageInfoService.GetRepositoryUrl(
+                Arg.Any<string>(),
+                Arg.Any<NuGetVersion>(),
+                Arg.Any<IEnumerable<Uri>>(),
+                Arg.Any<string>())
+            .Returns(repositoryUrl);
+
+        return new GitHubRepositoryStatusService(packageInfoService, new HttpClient(handler));
+    }
+
+    private static Task<RepositoryStatus> GetRepositoryStatus(GitHubRepositoryStatusService service)
+    {
+        return service.GetRepositoryStatus(
+            "Package",
+            NuGetVersion.Parse("1.0.0"),
+            Array.Empty<Uri>(),
+            "project.csproj");
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return handler(request, cancellationToken);
+        }
+    }
+}

--- a/test/DotNetOutdated.Tests/JsonFormatterTests.cs
+++ b/test/DotNetOutdated.Tests/JsonFormatterTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -55,19 +55,22 @@ public class JsonFormatterTests
                         "Name": "Microsoft.Extensions.Http.Diagnostics",
                         "ResolvedVersion": "9.0.0-preview.4.24261.1",
                         "LatestVersion": "9.0.0-preview.4.24263.5",
-                        "UpgradeSeverity": "Major"
+                        "UpgradeSeverity": "Major",
+                        "RepositoryStatus": "Unknown"
                       },
                       {
                         "Name": "Microsoft.Extensions.Http.Resilience",
                         "ResolvedVersion": "9.0.0-preview.4.24261.1",
                         "LatestVersion": "9.0.0-preview.4.24263.5",
-                        "UpgradeSeverity": "Major"
+                        "UpgradeSeverity": "Major",
+                        "RepositoryStatus": "Unknown"
                       },
                       {
                         "Name": "Microsoft.Extensions.Telemetry",
                         "ResolvedVersion": "9.0.0-preview.4.24261.1",
                         "LatestVersion": "9.0.0-preview.4.24263.5",
-                        "UpgradeSeverity": "Major"
+                        "UpgradeSeverity": "Major",
+                        "RepositoryStatus": "Unknown"
                       }
                     ]
                   }


### PR DESCRIPTION
## Summary

Reports packages whose source-code repository has been archived or deleted, even when the package itself isn't marked deprecated on NuGet.

Complementary to #181 (deprecated packages) — that covers explicit deprecation metadata; this covers the case where a package's own repo has quietly gone away while the NuGet listing stays untouched.

**Scope**: GitHub only. Other hosts (GitLab, Bitbucket, etc.) would need their own archived/deleted-detection semantics and API clients — intentionally left out to keep this change focused; the `IRepositoryStatusService` abstraction leaves room for additional providers later.

## How it works

- `NuGetPackageInfoService.GetRepositoryUrl` reads the `<repository>` URL from the package's nuspec — first from the locally-restored global-packages cache (no extra network call for packages already restored), falling back to a metadata download only when not present locally. Falls back to the nuspec's project URL if no repository URL is set.
- `GitHubRepositoryStatusService` parses `owner/repo` out of `github.com` URLs (including `git@github.com:` SCP-style and `.git` suffixes) and checks `GET api.github.com/repos/{owner}/{repo}`: 404 → `NotFound`, `archived: true` → `Archived`, otherwise `Active`. Results are cached per repo per run.
- Resilience: any failure (network error, timeout, rate limit, non-GitHub host) resolves to `Unknown` rather than throwing — the overall command never fails because of this check. Requests use a 5s timeout.
- Reporting: a "Repository Status" column appears in the console table only when at least one dependency is `Archived` or `NotFound` (kept quiet otherwise), plus new fields in the CSV, Markdown, and JSON output formats.

## Known limitation

The GitHub REST API is unauthenticated here (60 requests/hour per IP) — fine for typical project sizes, but large dependency trees run on the free plan may exhaust the quota, in which case remaining checks degrade to `Unknown` rather than failing.

## Test plan
- [x] `dotnet build` — clean, no new warnings
- [x] `dotnet test` — 217 passed, 0 failed (net8.0 and net9.0)
- [x] New unit tests for `GitHubRepositoryStatusService` covering: archived, active, not-found, timeout, non-GitHub URL, network failure
- [x] Manual smoke test via `dotnet run -- test-projects/development-dependencies`

Fixes #200